### PR TITLE
Add runtime cloth/rope configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ The master branch is the version the users outside the lab should use.
   - [Gurobi Licence](#gurobi-licence)
   - [Building](#building)
   - [Testing](#testing)
+- [Usage](#usage)
+  - [Rope Tracking](#rope-tracking)
+  - [Cloth Tracking](#cloth-tracking)
 - [Demos](#demos)
   - [Virtual Demos](#virtual-demos)
     - [Downloading The rosbags](#downloading-the-rosbags)
@@ -80,6 +83,41 @@ This will build and execute all CDCPD unit tests to ensure the package was insta
 
 Note: there isn't much special about the `test_cdcpd.sh` bash script, it simply starts a roscore and executes the `catkin test cdcpd` command with some added flags for simplifying things.
 
+## Usage
+
+To configure CDCPD for tracking rope versus cloth, several rosparams must be set (recommended to be in your launch file).
+
+### Rope Tracking
+
+ROS params and descriptions:
+- "deformable_object_type"
+  - The type of the deformable object being tracked. In this case, a rope.
+  - Type: string
+  - Value: "rope"
+- "num_points"
+  - The number of points the tracked rope will have.
+  - Type: int
+- "max_rope_length"
+  - The maximum length of the rope in meters.
+  - Type: float
+
+### Cloth Tracking
+
+ROS params and descriptions:
+- "deformable_object_type"
+  - The type of the deformable object being tracked. In this case, a cloth.
+  - Type: string
+  - Value: "cloth"
+- "length_initial_cloth"
+  - The initial length of the cloth in meters.
+  - Type: float
+- "width_initial_cloth"
+  - The initial width of the cloth in meters.
+  - Type: float
+- "grid_size_initial_guess_cloth"
+  - The size (in meters) of one square of the cloth template grid. Note! This is only providing an initial guess for the cloth template grid size. The actual grid size will be adjusted based on how well the grid size guess divides the supplied initial length and width.
+  - Type: float
+
 ## Demos
 
 ### Virtual Demos
@@ -129,7 +167,7 @@ To run with a realsense, without the obstacle or gripper constraints, try this:
 
 ```
 roslaunch realsense2_camera rs_camera.launch enable_pointcloud:=true
-roslaunch rviz -d cdcpd/rviz/realsense.rviz
+rviz -d cdcpd/rviz/realsense.rviz  # From local cdcpd directory
 roslaunch cdcpd realsense.launch
 ```
 
@@ -138,7 +176,7 @@ We also provide an example for the kinect, in our case the kinectv2, but as long
 
 ```
 roslaunch kinect2_calibration_files kinect2_bridge_tripodA.launch  # ARMLab internal usage
-roslaunch rviz -d cdcpd/rviz/kinect.rviz
+rviz -d cdcpd/rviz/kinect.rviz  # From local cdcpd directory
 roslaunch cdcpd kinect.launch
 ```
 

--- a/cdcpd/include/cdcpd/cdcpd_node.h
+++ b/cdcpd/include/cdcpd/cdcpd_node.h
@@ -63,12 +63,26 @@ struct CDCPD_Node_Parameters
     std::string const grippers_info_filename;
     int const num_points;
     float const max_rope_length;
+    float const length_initial_cloth;
+    float const width_initial_cloth;
+    float const grid_size_initial_guess_cloth;
     bool const moveit_enabled;
+    DeformableObjectType const deformable_object_type;
+
+private:
+    std::map<std::string, DeformableObjectType> obj_type_map_{
+        {"rope", DeformableObjectType::rope},
+        {"cloth", DeformableObjectType::cloth},
+    };
 };
 
 struct CDCPD_Moveit_Node {
 public:
     explicit CDCPD_Moveit_Node(std::string const& robot_namespace);
+
+    // Initializes the deformable object template based on the type selected when launching CDCPD
+    void initialize_deformable_object_configuration(Eigen::Vector3f const& rope_start_position,
+        Eigen::Vector3f const& rope_end_position);
 
     ObstacleConstraints find_nearest_points_and_normals(planning_scene_monitor::LockedPlanningSceneRW planning_scene,
                                                       Eigen::Isometry3d const& cdcpd_to_moveit);
@@ -130,7 +144,8 @@ public:
     unsigned int gripper_count;
     Eigen::MatrixXi gripper_indices;
 
-    RopeConfiguration rope_configuration;
+    std::unique_ptr<DeformableObjectConfiguration> deformable_object_configuration_;
+    // RopeConfiguration rope_configuration;
 
     tf2_ros::Buffer tf_buffer_;
     tf2_ros::TransformListener tf_listener_;

--- a/cdcpd/include/cdcpd/deformable_object_configuration.h
+++ b/cdcpd/include/cdcpd/deformable_object_configuration.h
@@ -1,60 +1,109 @@
 #pragma once
 
+#include <tuple>
+
 #include <Eigen/Dense>
 #include <pcl_ros/point_cloud.h>
 #include <pcl/point_types.h>
+#include "opencv2/imgproc.hpp"
+#include <opencv2/core/eigen.hpp>
 
 typedef pcl::PointCloud<pcl::PointXYZ> PointCloud;
 
+enum DeformableObjectType
+{
+    rope,
+    cloth
+};
 struct DeformableObjectTracking
 {
     DeformableObjectTracking(){}
 
     // Turns the passed in Matrix of XYZ points to a point cloud.
+    // TODO(dylan.colli): remove argument. Should just use the vertices member.
     void makeCloud(Eigen::Matrix3Xf const& points);
 
     // Copy constructor.
     DeformableObjectTracking(DeformableObjectTracking const& other);
 
-    Eigen::Matrix3Xf vertices{};
-    Eigen::Matrix2Xi edges{};
-    PointCloud::Ptr points;
+    // Sets the vertices from input point vector.
+    void setVertices(std::vector<cv::Point3f> const& vertex_points);
+
+    // Sets the edges from input edge vector.
+    void setEdges(std::vector<std::tuple<int, int>> const& edges);
+
+    Eigen::Matrix3Xf vertices_{};
+    Eigen::Matrix2Xi edges_{};
+    PointCloud::Ptr points_;
 };
 
 class DeformableObjectConfiguration
 {
 public:
+    DeformableObjectConfiguration(){}
     DeformableObjectConfiguration(int const num_points_);
 
     // Forms the deformable object tracking template. This needs to be overriden by derived classes
     // since this is dependent upon the type of deformable object we're tracking.
-    DeformableObjectTracking virtual makeTemplate(Eigen::Vector3f const& start_position,
-        Eigen::Vector3f const& end_position) = 0;
+    DeformableObjectTracking virtual makeTemplate() = 0;
 
     virtual ~DeformableObjectConfiguration(){}
 
-    void initializeTracking(Eigen::Vector3f const& start_position,
-        Eigen::Vector3f const& end_position);
+    void initializeTracking();
 
-    int const num_points;
-    DeformableObjectTracking tracked;
-    DeformableObjectTracking initial;
+    int num_points_;
+    float max_segment_length_;
+    DeformableObjectTracking tracked_;
+    DeformableObjectTracking initial_;
 };
 
 class RopeConfiguration : public DeformableObjectConfiguration
 {
 public:
-    RopeConfiguration(int const num_points_, float const max_rope_length_);
-    DeformableObjectTracking virtual makeTemplate(Eigen::Vector3f const& start_position,
-        Eigen::Vector3f const& end_position);
+    RopeConfiguration(int const num_points_, float const max_rope_length_,
+        Eigen::Vector3f const rope_start_position, Eigen::Vector3f const rope_end_position);
 
-    float const max_rope_length;
-    float const max_segment_length;
+    DeformableObjectTracking virtual makeTemplate();
+
+    float const max_rope_length_;
+    Eigen::Vector3f const rope_start_position_initial_;
+    Eigen::Vector3f const rope_end_position_initial_;
 };
 
 
-// TODO(dylan.colli): Make a derived class for cloth configuration.
-// class ClothConfiguration : public DeformableObjectConfiguration
-// {
+class ClothConfiguration : public DeformableObjectConfiguration
+{
+public:
+    ClothConfiguration(float const length_initial, float const width_initial,
+        float const grid_size_initial_guess);
 
-// };
+    DeformableObjectTracking virtual makeTemplate();
+
+    // Describes the affine transformation the initial template grid underwent to warp to the
+    // initial tracked template.
+    // NOTE: this is initialized to an identity affine transform.
+    cv::Mat template_affine_transform_ = (cv::Mat_<float>(4, 4) <<
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, 1);
+
+    // Describes the number of points the template is initialized with in the length direction.
+    // Length is downwards direction!
+    int const num_points_length_;
+
+    // Describes the number of points the template is initialized with in the width direction.
+    // Width is rightwards direction!
+    int const num_points_width_;
+
+    int const num_edges_;
+
+    // Initial length of the template.
+    float const length_initial_;
+
+    // Initial width of the template.
+    float const width_initial_;
+
+    // The supplied initial guess for the grid size.
+    float const grid_size_initial_guess_;
+};

--- a/cdcpd/src/cdcpd_node.cpp
+++ b/cdcpd/src/cdcpd_node.cpp
@@ -72,13 +72,23 @@ CDCPD_Publishers::CDCPD_Publishers(ros::NodeHandle& nh, ros::NodeHandle& ph)
 CDCPD_Node_Parameters::CDCPD_Node_Parameters(ros::NodeHandle& nh, ros::NodeHandle& ph)
     : points_name(ROSHelpers::GetParam<std::string>(ph, "points", "")),
       rgb_topic(ROSHelpers::GetParam<std::string>(ph, "rgb_topic", "/camera/color/image_raw")),
-      depth_topic(ROSHelpers::GetParam<std::string>(ph, "depth_topic", "/camera/depth/image_rect_raw")),
-      info_topic(ROSHelpers::GetParam<std::string>(ph, "info_topic", "/camera/depth/camera_info")),
-      camera_frame(ROSHelpers::GetParam<std::string>(ph, "camera_frame", "camera_color_optical_frame")),
-      grippers_info_filename(ROSHelpers::GetParamRequired<std::string>(ph, "grippers_info", "cdcpd_node")),
+      depth_topic(
+            ROSHelpers::GetParam<std::string>(ph, "depth_topic", "/camera/depth/image_rect_raw")),
+      info_topic(
+            ROSHelpers::GetParam<std::string>(ph, "info_topic", "/camera/depth/camera_info")),
+      camera_frame(
+            ROSHelpers::GetParam<std::string>(ph, "camera_frame", "camera_color_optical_frame")),
+      grippers_info_filename(
+            ROSHelpers::GetParamRequired<std::string>(ph, "grippers_info", "cdcpd_node")),
       num_points(ROSHelpers::GetParam<int>(nh, "rope_num_points", 11)),
       max_rope_length(ROSHelpers::GetParam<float>(nh, "max_rope_length", 1.0)),
-      moveit_enabled(ROSHelpers::GetParam<bool>(ph, "moveit_enabled", false))
+      length_initial_cloth(ROSHelpers::GetParam<float>(ph, "length_initial_cloth", 0.0)),
+      width_initial_cloth(ROSHelpers::GetParam<float>(ph, "width_initial_cloth", 0.0)),
+      grid_size_initial_guess_cloth(
+          ROSHelpers::GetParam<float>(ph, "grid_size_initial_guess_cloth", 0.0)),
+      moveit_enabled(ROSHelpers::GetParam<bool>(ph, "moveit_enabled", false)),
+      deformable_object_type(obj_type_map_[
+          ROSHelpers::GetParam<std::string>(ph, "deformable_object_type", "rope")])
 {}
 
 
@@ -89,7 +99,6 @@ CDCPD_Moveit_Node::CDCPD_Moveit_Node(std::string const& robot_namespace)
       publishers(nh, ph),
       node_params(nh, ph),
       cdcpd_params(ph),
-      rope_configuration(node_params.num_points, node_params.max_rope_length),
       scene_monitor_(std::make_shared<planning_scene_monitor::PlanningSceneMonitor>(robot_description_)),
       model_loader_(std::make_shared<robot_model_loader::RobotModelLoader>(robot_description_)),
       model_(model_loader_->getModel()),
@@ -125,9 +134,6 @@ CDCPD_Moveit_Node::CDCPD_Moveit_Node(std::string const& robot_namespace)
         gripper_indices = {};
     }
 
-    // Initial connectivity model of rope
-    ROS_DEBUG_STREAM_NAMED(LOGNAME, "max segment length " << rope_configuration.max_segment_length);
-
     // initialize start and end points for rope
     auto [init_q_config, init_q_dot] = get_q_config();
     Eigen::Vector3f start_position{Eigen::Vector3f::Zero()};
@@ -145,11 +151,11 @@ CDCPD_Moveit_Node::CDCPD_Moveit_Node(std::string const& robot_namespace)
         end_position << node_params.max_rope_length / 2, 0, 1.0;
     }
 
-    // TODO: decide on rope versus cloth configuration here.
-    rope_configuration.initializeTracking(start_position, end_position);
+    initialize_deformable_object_configuration(start_position, end_position);
 
-    std::unique_ptr<CDCPD> cdcpd_new(new CDCPD(nh, ph, rope_configuration.initial.points,
-        rope_configuration.initial.edges,
+    std::unique_ptr<CDCPD> cdcpd_new(new CDCPD(nh, ph,
+        deformable_object_configuration_->initial_.points_,
+        deformable_object_configuration_->initial_.edges_,
         cdcpd_params.objective_value_threshold, cdcpd_params.use_recovery, cdcpd_params.alpha,
         cdcpd_params.beta, cdcpd_params.lambda, cdcpd_params.k_spring, cdcpd_params.zeta,
         cdcpd_params.obstacle_cost_weight, cdcpd_params.fixed_points_weight));
@@ -182,6 +188,32 @@ CDCPD_Moveit_Node::CDCPD_Moveit_Node(std::string const& robot_namespace)
         ros::spin();
     }
   }
+
+void CDCPD_Moveit_Node::initialize_deformable_object_configuration(
+    Eigen::Vector3f const& rope_start_position, Eigen::Vector3f const& rope_end_position)
+{
+    if (node_params.deformable_object_type == DeformableObjectType::rope)
+    {
+        std::unique_ptr<RopeConfiguration> configuration = std::unique_ptr<RopeConfiguration>(
+            new RopeConfiguration(node_params.num_points, node_params.max_rope_length,
+                rope_start_position, rope_end_position));
+        // Have to call initializeTracking() before casting to base class since it relies on virtual
+        // functions.
+        configuration->initializeTracking();
+        deformable_object_configuration_ = std::move(configuration);
+    }
+    else if (node_params.deformable_object_type == DeformableObjectType::cloth)
+    {
+        std::unique_ptr<ClothConfiguration> configuration =
+            std::unique_ptr<ClothConfiguration>(
+                new ClothConfiguration(node_params.length_initial_cloth,
+                    node_params.width_initial_cloth, node_params.grid_size_initial_guess_cloth));
+        // Have to call initializeTracking() before casting to base class since it relies on virtual
+        // functions.
+        configuration->initializeTracking();
+        deformable_object_configuration_ = std::move(configuration);
+    }
+}
 
 ObstacleConstraints CDCPD_Moveit_Node::find_nearest_points_and_normals(
     planning_scene_monitor::LockedPlanningSceneRW planning_scene,
@@ -420,10 +452,11 @@ void CDCPD_Moveit_Node::callback(cv::Mat const& rgb, cv::Mat const& depth,
 
     auto const hsv_mask = getHsvMask(ph, rgb);
     auto const out = (*cdcpd)(rgb, depth, hsv_mask, intrinsics,
-                              rope_configuration.tracked.points,
-                              obstacle_constraints, rope_configuration.max_segment_length, q_dot,
+                              deformable_object_configuration_->tracked_.points_,
+                              obstacle_constraints,
+                              deformable_object_configuration_->max_segment_length_, q_dot,
                               q_config, gripper_indices);
-    rope_configuration.tracked.points = out.gurobi_output;
+    deformable_object_configuration_->tracked_.points_ = out.gurobi_output;
     publish_outputs(t0, out);
     reset_if_bad(out);
 };
@@ -443,9 +476,10 @@ void CDCPD_Moveit_Node::points_callback(const sensor_msgs::PointCloud2ConstPtr& 
     pcl::fromPCLPointCloud2(points_v2, *points);
     ROS_DEBUG_STREAM_NAMED(LOGNAME, "unfiltered points: " << points->size());
 
-    auto const out = (*cdcpd)(points, rope_configuration.tracked.points, obstacle_constraints,
-        rope_configuration.max_segment_length, q_dot, q_config, gripper_indices);
-    rope_configuration.tracked.points = out.gurobi_output;
+    auto const out = (*cdcpd)(points, deformable_object_configuration_->tracked_.points_,
+        obstacle_constraints, deformable_object_configuration_->max_segment_length_, q_dot,
+        q_config, gripper_indices);
+    deformable_object_configuration_->tracked_.points_ = out.gurobi_output;
     publish_outputs(t0, out);
     reset_if_bad(out);
 }
@@ -473,9 +507,9 @@ void CDCPD_Moveit_Node::publish_bbox() const
 void CDCPD_Moveit_Node::publish_template() const
 {
     auto time = ros::Time::now();
-    rope_configuration.tracked.points->header.frame_id = node_params.camera_frame;
-    pcl_conversions::toPCL(time, rope_configuration.tracked.points->header.stamp);
-    publishers.pre_template_publisher.publish(rope_configuration.tracked.points);
+    deformable_object_configuration_->tracked_.points_->header.frame_id = node_params.camera_frame;
+    pcl_conversions::toPCL(time, deformable_object_configuration_->tracked_.points_->header.stamp);
+    publishers.pre_template_publisher.publish(deformable_object_configuration_->tracked_.points_);
 }
 
 ObstacleConstraints CDCPD_Moveit_Node::get_obstacle_constraints()
@@ -483,7 +517,8 @@ ObstacleConstraints CDCPD_Moveit_Node::get_obstacle_constraints()
     ObstacleConstraints obstacle_constraints;
     if (moveit_ready and node_params.moveit_enabled)
     {
-        obstacle_constraints = get_moveit_obstacle_constriants(rope_configuration.tracked.points);
+        obstacle_constraints = get_moveit_obstacle_constriants(
+            deformable_object_configuration_->tracked_.points_);
         ROS_DEBUG_NAMED(LOGNAME + ".moveit", "Got moveit obstacle constraints");
     }
     return obstacle_constraints;
@@ -553,12 +588,14 @@ void CDCPD_Moveit_Node::publish_outputs(ros::Time const& t0, CDCPD::Output const
 
     // compute length and print that for debugging purposes
     auto output_length{0.0};
-    for (auto point_idx{0}; point_idx < rope_configuration.tracked.points->size() - 1; ++point_idx)
+    for (auto point_idx{0};
+         point_idx < deformable_object_configuration_->tracked_.points_->size() - 1;
+         ++point_idx)
     {
         Eigen::Vector3f const p =
-          rope_configuration.tracked.points->at(point_idx + 1).getVector3fMap();
+          deformable_object_configuration_->tracked_.points_->at(point_idx + 1).getVector3fMap();
         Eigen::Vector3f const p_next =
-          rope_configuration.tracked.points->at(point_idx).getVector3fMap();
+          deformable_object_configuration_->tracked_.points_->at(point_idx).getVector3fMap();
         output_length += (p_next - p).norm();
     }
     ROS_DEBUG_STREAM_NAMED(LOGNAME + ".length", "length = " << output_length << " max length = "
@@ -575,8 +612,9 @@ void CDCPD_Moveit_Node::reset_if_bad(CDCPD::Output const& out)
         out.status == OutputStatus::ObjectiveTooHigh)
     {
         // Recreate CDCPD from initial tracking.
-        std::unique_ptr<CDCPD> cdcpd_new(new CDCPD(nh, ph, rope_configuration.initial.points,
-            rope_configuration.initial.edges,
+        std::unique_ptr<CDCPD> cdcpd_new(new CDCPD(nh, ph,
+            deformable_object_configuration_->initial_.points_,
+            deformable_object_configuration_->initial_.edges_,
             cdcpd_params.objective_value_threshold, cdcpd_params.use_recovery, cdcpd_params.alpha,
             cdcpd_params.beta, cdcpd_params.lambda, cdcpd_params.k_spring, cdcpd_params.zeta,
             cdcpd_params.obstacle_cost_weight, cdcpd_params.fixed_points_weight));

--- a/cdcpd/src/deformable_object_configuration.cpp
+++ b/cdcpd/src/deformable_object_configuration.cpp
@@ -1,16 +1,22 @@
 #include "cdcpd/deformable_object_configuration.h"
 
-DeformableObjectTracking::DeformableObjectTracking(DeformableObjectTracking const& other)
+// Unravels the index for row, col and gives the total index (row major)
+int unravel_indices(int row, int col, int num_points_width)
 {
-    vertices = other.vertices;
-    edges = other.edges;
-    // Need to be careful so that the newly tracked points point to different memory than the
-    // "other" tracked points
-    points = PointCloud::Ptr(new PointCloud(*other.points));
+    return row * num_points_width + col;
 }
 
-DeformableObjectConfiguration::DeformableObjectConfiguration(int const num_points_)
-    : num_points(num_points_)
+DeformableObjectTracking::DeformableObjectTracking(DeformableObjectTracking const& other)
+{
+    vertices_ = other.vertices_;
+    edges_ = other.edges_;
+    // Need to be careful so that the newly tracked points point to different memory than the
+    // "other" tracked points
+    points_ = PointCloud::Ptr(new PointCloud(*other.points_));
+}
+
+DeformableObjectConfiguration::DeformableObjectConfiguration(int const num_points)
+    : num_points_(num_points)
 {}
 
 void DeformableObjectTracking::makeCloud(Eigen::Matrix3Xf const& points_mat)
@@ -21,43 +27,141 @@ void DeformableObjectTracking::makeCloud(Eigen::Matrix3Xf const& points_mat)
     auto const& c = points_mat.col(i);
     cloud->push_back(pcl::PointXYZ(c(0), c(1), c(2)));
   }
-  points = cloud;
+  points_ = cloud;
 }
 
-void DeformableObjectConfiguration::initializeTracking(Eigen::Vector3f const& start_position,
-    Eigen::Vector3f const& end_position)
+void DeformableObjectTracking::setVertices(std::vector<cv::Point3f> const& vertex_points)
 {
-    DeformableObjectTracking object_tracking = makeTemplate(start_position, end_position);
-    tracked = DeformableObjectTracking(object_tracking);
-    initial = DeformableObjectTracking(object_tracking);
-}
+    Eigen::Matrix3Xf vertices_new(3, vertex_points.size());
+    int i = 0;
+    for (auto const& pt : vertex_points)
+    {
+        vertices_new(0, i) = pt.x;
+        vertices_new(1, i) = pt.y;
+        vertices_new(2, i) = pt.z;
 
-RopeConfiguration::RopeConfiguration(int const num_points_, float const max_rope_length_)
-    : DeformableObjectConfiguration{num_points_},
-      max_rope_length(max_rope_length_),
-      max_segment_length(max_rope_length / static_cast<float>(num_points))
-{}
-
-DeformableObjectTracking RopeConfiguration::makeTemplate(Eigen::Vector3f const& start_position,
-    Eigen::Vector3f const& end_position)
-{
-    Eigen::Matrix3Xf template_vertices(3, num_points);  // Y^0 in the paper
-    Eigen::VectorXf thetas = Eigen::VectorXf::LinSpaced(num_points, 0, 1);
-    for (int i = 0; i < num_points; ++i) {
-        auto const theta = thetas.row(i);
-        template_vertices.col(i) = (end_position - start_position) * theta + start_position;
+        ++i;
     }
-    Eigen::Matrix2Xi template_edges(2, num_points - 1);
+    vertices_ = vertices_new;
+}
+
+void DeformableObjectTracking::setEdges(std::vector<std::tuple<int, int>> const& edges)
+{
+    Eigen::Matrix2Xi edges_new(2, edges.size());
+    int i = 0;
+    for (auto const& edge : edges)
+    {
+        edges_new(0, i) = std::get<0>(edge);
+        edges_new(1, i) = std::get<1>(edge);
+        ++i;
+    }
+    edges_ = edges_new;
+}
+
+void DeformableObjectConfiguration::initializeTracking()
+{
+    DeformableObjectTracking object_tracking = makeTemplate();
+    tracked_ = DeformableObjectTracking(object_tracking);
+    initial_ = DeformableObjectTracking(object_tracking);
+}
+
+RopeConfiguration::RopeConfiguration(int const num_points, float const max_rope_length,
+    Eigen::Vector3f const rope_start_position, Eigen::Vector3f const rope_end_position)
+    : DeformableObjectConfiguration{num_points},
+      max_rope_length_(max_rope_length),
+      rope_start_position_initial_(rope_start_position),
+      rope_end_position_initial_(rope_end_position)
+{
+    max_segment_length_ = max_rope_length / (static_cast<float>(num_points) - 1);
+}
+
+
+DeformableObjectTracking RopeConfiguration::makeTemplate()
+{
+    Eigen::Matrix3Xf template_vertices(3, num_points_);  // Y^0 in the paper
+    Eigen::VectorXf thetas = Eigen::VectorXf::LinSpaced(num_points_, 0, 1);
+    for (int i = 0; i < num_points_; ++i) {
+        auto const theta = thetas.row(i);
+        template_vertices.col(i) = (rope_end_position_initial_ - rope_start_position_initial_)
+            * theta + rope_start_position_initial_;
+    }
+    Eigen::Matrix2Xi template_edges(2, num_points_ - 1);
     template_edges(0, 0) = 0;
-    template_edges(1, template_edges.cols() - 1) = num_points - 1;
+    template_edges(1, template_edges.cols() - 1) = num_points_ - 1;
     for (int i = 1; i <= template_edges.cols() - 1; ++i) {
         template_edges(0, i) = i;
         template_edges(1, i - 1) = i;
     }
     DeformableObjectTracking configuration;
-    configuration.vertices = template_vertices;
-    configuration.edges = template_edges;
+    configuration.vertices_ = template_vertices;
+    configuration.edges_ = template_edges;
     configuration.makeCloud(template_vertices);
+
+    return configuration;
+}
+
+ClothConfiguration::ClothConfiguration(float const length_initial, float const width_initial,
+    float const grid_size_initial_guess)
+    : DeformableObjectConfiguration{},
+      length_initial_{length_initial},
+      width_initial_{width_initial},
+      grid_size_initial_guess_{grid_size_initial_guess},
+      num_points_length_{std::round(length_initial / grid_size_initial_guess) + 2},
+      num_points_width_{std::round(width_initial / grid_size_initial_guess) + 2},
+      num_edges_{(num_points_length_ - 1) * num_points_width_
+                  + (num_points_width_ - 1) * num_points_length_}
+{
+    num_points_ = num_points_length_ * num_points_width_;
+
+    // Calculate the actual max_segment_length_ based off of the number of segments in both the
+    // length and the width directions.
+    int num_segments_length = num_points_length_ - 1;
+    int num_segments_width = num_points_width_ - 1;
+    float grid_size_initial_actual_length =
+        length_initial_ / static_cast<float>(num_segments_length);
+    float grid_size_initial_actual_width = width_initial_ / static_cast<float>(num_segments_width);
+    max_segment_length_ = std::min({grid_size_initial_actual_length,
+        grid_size_initial_actual_width});
+}
+
+DeformableObjectTracking ClothConfiguration::makeTemplate()
+{
+    DeformableObjectTracking configuration;
+    std::vector<std::tuple<int, int>> edges_list;
+    
+    std::vector<cv::Point3f> template_original_points;
+    int idx = 0;
+    for (int i = 0; i < num_points_length_; ++i)
+    {
+        for (int j = 0; j < num_points_width_; ++j)
+        {
+            cv::Point3f pt(i * max_segment_length_, j * max_segment_length_, 0);
+            template_original_points.push_back(pt);
+
+            if (i + 1 < num_points_length_)
+            {
+                edges_list.push_back({idx, unravel_indices(i + 1, j, num_points_width_)});
+            }
+            if (j + 1 < num_points_length_)
+            {
+                edges_list.push_back({idx, unravel_indices(i, j + 1, num_points_width_)});
+            }
+
+            ++idx;
+        }
+    }
+
+    // Get the warped template points based on supplied affine transformation.
+    std::vector<cv::Point3f> template_warped_points;
+    cv::perspectiveTransform(template_original_points, template_warped_points,
+        template_affine_transform_);
+
+
+    // Store the warped template in the returned configuration.
+    configuration.setVertices(template_warped_points);
+    configuration.setEdges(edges_list);
+
+    configuration.makeCloud(configuration.vertices_);
 
     return configuration;
 }

--- a/cdcpd/tests/integration/static_rope.cpp
+++ b/cdcpd/tests/integration/static_rope.cpp
@@ -23,8 +23,8 @@ RopeConfiguration getInitialTracking(float const max_rope_length, int const num_
     start_position << -max_rope_length / 2, 0, 1.0;
     end_position << max_rope_length / 2, 0, 1.0;
 
-    RopeConfiguration rope_configuration(num_points, max_rope_length);
-    rope_configuration.initializeTracking(start_position, end_position);
+    RopeConfiguration rope_configuration(num_points, max_rope_length, start_position, end_position);
+    rope_configuration.initializeTracking();
 
     return rope_configuration;
 }
@@ -34,7 +34,7 @@ CDCPD initializeCdcpdSimulator(DeformableObjectTracking const& rope_tracking_ini
     if (PRINT_DEBUG_MESSAGES)
     {
         std::stringstream ss;
-        ss << rope_tracking_initial.edges;
+        ss << rope_tracking_initial.edges_;
         ROS_WARN("Initial template edges");
         ROS_WARN(ss.str().c_str());
     }
@@ -50,7 +50,7 @@ CDCPD initializeCdcpdSimulator(DeformableObjectTracking const& rope_tracking_ini
     float const obstacle_cost_weight = 0.001;
     float const fixed_points_weight = 10.0;
 
-    CDCPD cdcpd = CDCPD(rope_tracking_initial.points, rope_tracking_initial.edges,
+    CDCPD cdcpd = CDCPD(rope_tracking_initial.points_, rope_tracking_initial.edges_,
         objective_value_threshold, use_recovery, alpha, beta, lambda, k, zeta, obstacle_cost_weight,
         fixed_points_weight);
 
@@ -108,11 +108,11 @@ TEST(StaticRope, testResimPointEquivalency)
     float const max_rope_length = 0.46F;  // Taken from kinect_tripodB.launch
     int const num_points = 15;  // Taken from kinect_tripodB.launch
     RopeConfiguration rope_configuration = getInitialTracking(max_rope_length, num_points);
-    CDCPD cdcpd_sim = initializeCdcpdSimulator(rope_configuration.initial);
+    CDCPD cdcpd_sim = initializeCdcpdSimulator(rope_configuration.initial_);
 
     auto input_clouds = readCdcpdInputPointClouds(bag);
     PointCloud::Ptr tracked_points = resimulateCdcpd(cdcpd_sim, input_clouds,
-        rope_configuration.initial.points, max_rope_length, num_points);
+        rope_configuration.initial_.points_, max_rope_length, num_points);
 
     expectPointCloudsEqual(*pt_cloud_last, *tracked_points);
 

--- a/cdcpd/tests/unit/include/ClothConfigurationTest.h
+++ b/cdcpd/tests/unit/include/ClothConfigurationTest.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include "cdcpd/deformable_object_configuration.h"
+#include "test_utils.h"
+
+// Tests the initialization of a very simple template, a 2x2 cloth
+TEST(ClothConfigurationTest, simpleClothConfigInitializationBagGridSizeGuess)
+{
+    // The following values will give a 2x2 template
+    float const cloth_length = 1.0;
+    float const cloth_width = 1.0;
+    float const grid_size_initial_guess = 0.76;
+    ClothConfiguration cloth_config{cloth_length, cloth_width, grid_size_initial_guess};
+
+    EXPECT_FLOAT_EQ(cloth_config.length_initial_, cloth_length);
+    EXPECT_FLOAT_EQ(cloth_config.width_initial_, cloth_width);
+    EXPECT_FLOAT_EQ(cloth_config.grid_size_initial_guess_, grid_size_initial_guess);
+    EXPECT_FLOAT_EQ(cloth_config.max_segment_length_, 0.5F);
+    EXPECT_EQ(cloth_config.num_points_length_, 3);
+    EXPECT_EQ(cloth_config.num_points_width_, 3);
+    EXPECT_EQ(cloth_config.num_points_, 9);
+    EXPECT_EQ(cloth_config.num_edges_, 12);
+}
+
+// Tests the tracking initialization of a very simple template, a 2x2 cloth
+TEST(ClothConfigurationTest, simpleClothConfigurationTemplateInitializationBadGridSizeGuess)
+{
+    // The following values give a 2x2 template
+    float const cloth_length = 1.0;
+    float const cloth_width = 1.0;
+    float const grid_size_initial_guess = 0.76;
+    ClothConfiguration config_test{cloth_length, cloth_width, grid_size_initial_guess};
+    config_test.initializeTracking();
+
+    // Setup the expected points and vertices
+    DeformableObjectTracking tracking_expected;
+    std::vector<cv::Point3f> vertices_expected = {
+        {0, 0, 0},
+        {0, 0.5, 0},
+        {0, 1, 0},
+        {0.5, 0, 0},
+        {0.5, 0.5, 0},
+        {0.5, 1, 0},
+        {1, 0, 0},
+        {1, 0.5, 0},
+        {1, 1, 0}
+    };
+    std::vector<std::tuple<int, int>> edges_expected = {
+        {0, 3},
+        {0, 1},
+        {1, 4},
+        {1, 2},
+        {2, 5},
+        {3, 6},
+        {3, 4},
+        {4, 7},
+        {4, 5},
+        {5, 8},
+        {6, 7},
+        {7, 8}
+    };
+    tracking_expected.setVertices(vertices_expected);
+    tracking_expected.setEdges(edges_expected);
+
+    expectEigenMatsEqual(config_test.tracked_.vertices_, tracking_expected.vertices_);
+    expectEigenMatsEqual(config_test.tracked_.edges_, tracking_expected.edges_);
+}

--- a/cdcpd/tests/unit/include/DeformableObjectTrackingTest.h
+++ b/cdcpd/tests/unit/include/DeformableObjectTrackingTest.h
@@ -9,27 +9,27 @@
 TEST(DeformableObjectTrackingTest, copyConstructor)
 {
     DeformableObjectTracking* track_1 = new DeformableObjectTracking();
-    track_1->vertices = Eigen::Matrix<float, 3, 1>{};
-    track_1->vertices << 0.0F, 1.0F, 2.0F;
-    track_1->edges = Eigen::Matrix<int, 2, 1>{};
-    track_1->edges << 0, 1;
-    track_1->points = PointCloud::Ptr(new PointCloud);
-    track_1->points->push_back(pcl::PointXYZ{0, 1, 2});
+    track_1->vertices_ = Eigen::Matrix<float, 3, 1>{};
+    track_1->vertices_ << 0.0F, 1.0F, 2.0F;
+    track_1->edges_ = Eigen::Matrix<int, 2, 1>{};
+    track_1->edges_ << 0, 1;
+    track_1->points_ = PointCloud::Ptr(new PointCloud);
+    track_1->points_->push_back(pcl::PointXYZ{0, 1, 2});
 
     DeformableObjectTracking* track_2 = new DeformableObjectTracking(*track_1);
 
-    track_1->vertices = Eigen::Matrix<float, 3, 1>{};
-    track_1->vertices << 3.0F, 4.0F, 5.0F;
-    track_1->edges = Eigen::Matrix<int, 2, 1>{};
-    track_1->edges << 2, 3;
-    track_1->points = PointCloud::Ptr(new PointCloud);
-    track_1->points->push_back(pcl::PointXYZ{3, 4, 5});
+    track_1->vertices_ = Eigen::Matrix<float, 3, 1>{};
+    track_1->vertices_ << 3.0F, 4.0F, 5.0F;
+    track_1->edges_ = Eigen::Matrix<int, 2, 1>{};
+    track_1->edges_ << 2, 3;
+    track_1->points_ = PointCloud::Ptr(new PointCloud);
+    track_1->points_->push_back(pcl::PointXYZ{3, 4, 5});
 
-    EXPECT_FALSE(track_1->vertices.isApprox(track_2->vertices));
+    EXPECT_FALSE(track_1->vertices_.isApprox(track_2->vertices_));
 
-    EXPECT_FALSE(track_1->edges.isApprox(track_2->edges));
+    EXPECT_FALSE(track_1->edges_.isApprox(track_2->edges_));
 
-    EXPECT_FALSE(track_1->points->points[0].x == track_2->points->points[0].x);
-    EXPECT_FALSE(track_1->points->points[0].y == track_2->points->points[0].y);
-    EXPECT_FALSE(track_1->points->points[0].z == track_2->points->points[0].z);
+    EXPECT_FALSE(track_1->points_->points[0].x == track_2->points_->points[0].x);
+    EXPECT_FALSE(track_1->points_->points[0].y == track_2->points_->points[0].y);
+    EXPECT_FALSE(track_1->points_->points[0].z == track_2->points_->points[0].z);
 }

--- a/cdcpd/tests/unit/include/RopeConfigurationTest.h
+++ b/cdcpd/tests/unit/include/RopeConfigurationTest.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <tuple>
+#include <iostream>
+
+#include <gtest/gtest.h>
+
+#include "cdcpd/deformable_object_configuration.h"
+#include "test_utils.h"
+
+// Tests a simple rope configuration for correctness.
+TEST(RopeConfigurationTest, simpleRopeConfigInitialization)
+{
+    int const num_points = 5;
+    float const max_rope_length = 1.0;
+    Eigen::Vector3f start_position{0, 0, 0};
+    Eigen::Vector3f end_position{max_rope_length, 0, 0};
+    RopeConfiguration config{num_points, max_rope_length, start_position, end_position};
+
+    int num_rope_segments = num_points - 1;
+    float const max_segment_length = max_rope_length / static_cast<float>(num_rope_segments);
+
+    EXPECT_EQ(config.num_points_, num_points);
+    EXPECT_FLOAT_EQ(config.max_rope_length_, max_rope_length);
+    EXPECT_FLOAT_EQ(config.max_segment_length_, max_segment_length);
+}
+
+TEST(RopeConfigurationTest, simpleRopeConfigTemplateInitialization)
+{
+    int const num_points = 5;
+    float const max_rope_length = 1.0;
+    Eigen::Vector3f start_position{0, 0, 0};
+    Eigen::Vector3f end_position{max_rope_length, 0, 0};
+    RopeConfiguration config{num_points, max_rope_length, start_position, end_position};
+
+    config.initializeTracking();
+
+    DeformableObjectTracking track_expected;
+    std::vector<cv::Point3f> vertices_expected = {
+        {0, 0, 0},
+        {0.25, 0, 0},
+        {0.5, 0, 0},
+        {0.75, 0, 0},
+        {1.0, 0, 0}
+    };
+    std::vector<std::tuple<int, int>> edges_expected;
+    for (int i = 0; i < num_points - 1; ++i)
+    {
+        edges_expected.push_back(std::make_tuple(i, i + 1));
+    }
+    track_expected.setVertices(vertices_expected);
+    track_expected.setEdges(edges_expected);
+
+    expectEigenMatsEqual(config.tracked_.vertices_, track_expected.vertices_);
+    expectEigenMatsEqual(config.tracked_.edges_, track_expected.edges_);
+}

--- a/cdcpd/tests/unit/include/test_utils.h
+++ b/cdcpd/tests/unit/include/test_utils.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <Eigen/Dense>
+
+void expectEigenMatsEqual(Eigen::Matrix3Xf const& lhs, Eigen::Matrix3Xf const& rhs)
+{
+    EXPECT_TRUE(lhs.rows() == rhs.rows())<< "Eigen::Matrix3Xf Failed! Test:\n" << lhs.rows() << "\nTruth:\n" << rhs.rows();
+    EXPECT_TRUE(lhs.cols() == rhs.cols())<< "Eigen::Matrix3Xf Failed! Test:\n" << lhs.cols() << "\nTruth:\n" << rhs.cols();
+    EXPECT_TRUE(lhs.isApprox(rhs, 1e-3)) << "Eigen::Matrix3Xf Failed! Test:\n" << lhs << "\nTruth:\n" << rhs;
+}
+
+void expectEigenMatsEqual(Eigen::Matrix2Xi const& lhs, Eigen::Matrix2Xi const& rhs)
+{
+    EXPECT_TRUE(lhs.rows() == rhs.rows())<< "Eigen::Matrix2Xi Failed! Test:\n" << lhs.rows() << "\nTruth:\n" << rhs.rows();
+    EXPECT_TRUE(lhs.cols() == rhs.cols())<< "Eigen::Matrix2Xi Failed! Test:\n" << lhs.cols() << "\nTruth:\n" << rhs.cols();
+    EXPECT_TRUE(lhs.isApprox(rhs))       << "Eigen::Matrix2Xi Failed! Test:\n" << lhs << "\nTruth:\n" << rhs;
+}

--- a/cdcpd/tests/unit/main.cpp
+++ b/cdcpd/tests/unit/main.cpp
@@ -5,6 +5,8 @@
 #include "MeshConversionTest.h"
 #include "BoxNearestPointsTest.h"
 #include "DeformableObjectTrackingTest.h"
+#include "RopeConfigurationTest.h"
+#include "ClothConfigurationTest.h"
 
 int main(int argc, char **argv){
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
- Modifies the DeformableObjectConfiguration base class to be much more generic, allowing for initialization of both rope and cloth derived classes while also allowing for the CDCPD_Moveit_Node to keep a smart pointer to the base class. This cleans the code up much more and allows for the runtime choice of tracking cloth or rope.
- Unfortunately, this does rely on rosparams to do this runtime choice between cloth and rope tracking. This can be addressed in the future.
- Adds skeleton code for warping cloth template initialization by an affine transform. This will be helpful when initializing cloth tracking (potentially multi-template tracking) based off of segmentation of the incoming point cloud or RGBD data.
- Updates the readme to assist with configuring cloth versus rope tracking.
- Additionally addresses #20 and #28