### PR TITLE
Add Segmentation Class

### DIFF
--- a/cdcpd/CMakeLists.txt
+++ b/cdcpd/CMakeLists.txt
@@ -66,6 +66,7 @@ add_library(cdcpd SHARED
         src/optimizer.cpp
         src/obs_util.cpp
         src/past_template_matcher.cpp
+        src/segmenter.cpp
         )
 target_include_directories(cdcpd PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/cdcpd/include/cdcpd/cdcpd.h
+++ b/cdcpd/include/cdcpd/cdcpd.h
@@ -35,7 +35,6 @@ typedef pcl::PointXYZHSV PointHSV;
 typedef pcl::PointCloud<pcl::PointXYZ> PointCloud;
 typedef pcl::PointCloud<PointRGB> PointCloudRGB;
 typedef pcl::PointCloud<PointHSV> PointCloudHSV;
-inline Eigen::Vector3f const bounding_box_extend(0.1, 0.2, 0.1);
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 typedef K::FT FT;

--- a/cdcpd/include/cdcpd/cdcpd_node.h
+++ b/cdcpd/include/cdcpd/cdcpd_node.h
@@ -28,6 +28,7 @@
 #include "cdcpd/cdcpd.h"
 #include "cdcpd_ros/camera_sub.h"
 #include "cdcpd/deformable_object_configuration.h"
+#include "cdcpd/segmenter.h"
 
 typedef pcl::PointCloud<pcl::PointXYZ> PointCloud;
 namespace gm = geometry_msgs;
@@ -139,7 +140,6 @@ public:
     Eigen::MatrixXi gripper_indices;
 
     std::unique_ptr<DeformableObjectConfiguration> deformable_object_configuration_;
-    // RopeConfiguration rope_configuration;
 
     tf2_ros::Buffer tf_buffer_;
     tf2_ros::TransformListener tf_listener_;

--- a/cdcpd/include/cdcpd/segmenter.h
+++ b/cdcpd/include/cdcpd/segmenter.h
@@ -21,12 +21,7 @@ typedef pcl::PointCloud<PointHSV> PointCloudHSV;
 inline Eigen::Vector3f const bounding_box_extend(0.1, 0.2, 0.1);
 std::string const LOGNAME_SEGMENTER = "cdcpd_segmenter";
 
-// class SegmentationOutput
-// {
-
-// };
-
-// The base calss that all Segmenter classes should inherit from. This defines the functions with
+// The base class that all Segmenter classes should inherit from. This defines the functions with
 // which the user will interact with the Segmenter.
 // Template argument here is for the type of the segmented point cloud.
 template<typename T>
@@ -36,12 +31,12 @@ public:
     Segmenter(){}
     virtual ~Segmenter(){}
 
-    // Copies the segmented point cloud. This prevents accidentally making changes to the output
-    // of the segmentation.
+    // Return a copy of the segmented point cloud. This prevents accidentally making changes to the
+    // output of the segmentation.
     virtual T get_segmented_cloud() const = 0;
 
     // Do the segmentation and store output as member variables of this class.
-     virtual void segment(const PointCloudRGB::Ptr & inputs_points) = 0;
+    virtual void segment(const PointCloudRGB::Ptr & inputs_points) = 0;
 
 protected:
     // The segmented point cloud.
@@ -72,7 +67,7 @@ public:
 
     virtual PointCloudHSV get_segmented_cloud() const override;
 
-    void segment(const PointCloudRGB::Ptr & input_points);
+    virtual void segment(const PointCloudRGB::Ptr & input_points);
 
     Eigen::Vector3f const last_lower_bounding_box_;
     Eigen::Vector3f const last_upper_bounding_box_;

--- a/cdcpd/include/cdcpd/segmenter.h
+++ b/cdcpd/include/cdcpd/segmenter.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <string>
+
+#include <Eigen/Dense>
+#include <pcl/filters/crop_box.h>
+#include <pcl/filters/passthrough.h>
+#include <pcl/filters/voxel_grid.h>
+#include <pcl/point_types.h>
+#include <pcl/point_types_conversion.h>
+#include <ros/ros.h>
+
+#include <arc_utilities/ros_helpers.hpp>
+
+typedef pcl::PointXYZRGB PointRGB;
+typedef pcl::PointXYZHSV PointHSV;
+typedef pcl::PointCloud<pcl::PointXYZ> PointCloud;
+typedef pcl::PointCloud<PointRGB> PointCloudRGB;
+typedef pcl::PointCloud<PointHSV> PointCloudHSV;
+
+inline Eigen::Vector3f const bounding_box_extend(0.1, 0.2, 0.1);
+std::string const LOGNAME_SEGMENTER = "cdcpd_segmenter";
+
+// class SegmentationOutput
+// {
+
+// };
+
+// The base calss that all Segmenter classes should inherit from. This defines the functions with
+// which the user will interact with the Segmenter.
+// Template argument here is for the type of the segmented point cloud.
+template<typename T>
+class Segmenter
+{
+public:
+    Segmenter(){}
+    virtual ~Segmenter(){}
+
+    // Copies the segmented point cloud. This prevents accidentally making changes to the output
+    // of the segmentation.
+    virtual T get_segmented_cloud() const = 0;
+
+    // Do the segmentation and store output as member variables of this class.
+     virtual void segment(const PointCloudRGB::Ptr & inputs_points) = 0;
+
+protected:
+    // The segmented point cloud.
+    // Adding const here ensures that the segmented point cloud is not changed downstream of
+    // segmentation, preventing unexpected behavior if the user modifies the segmented point cloud.
+    std::unique_ptr<const T> segmented_points_;
+};
+
+class SegmenterHSV : public Segmenter<PointCloudHSV>
+{
+public:
+
+    struct SegmenterParameters
+    {
+    public:
+        SegmenterParameters(ros::NodeHandle& ph);
+
+        float const hue_min;
+        float const hue_max;
+        float const sat_min;
+        float const sat_max;
+        float const val_min;
+        float const val_max;
+    };
+
+    SegmenterHSV(ros::NodeHandle& ph, Eigen::Vector3f const last_lower_bounding_box,
+        Eigen::Vector3f const last_upper_bounding_box);
+
+    virtual PointCloudHSV get_segmented_cloud() const override;
+
+    void segment(const PointCloudRGB::Ptr & input_points);
+
+    Eigen::Vector3f const last_lower_bounding_box_;
+    Eigen::Vector3f const last_upper_bounding_box_;
+    SegmenterParameters const params_;
+};

--- a/cdcpd/src/segmenter.cpp
+++ b/cdcpd/src/segmenter.cpp
@@ -1,0 +1,84 @@
+#include "cdcpd/segmenter.h"
+
+SegmenterHSV::SegmenterParameters::SegmenterParameters(ros::NodeHandle& ph)
+    : hue_min(ROSHelpers::GetParamDebugLog<float>(ph, "hue_min", 340.0)),
+      hue_max(ROSHelpers::GetParamDebugLog<float>(ph, "hue_max", 20.0)),
+      sat_min(ROSHelpers::GetParamDebugLog<float>(ph, "saturation_min", 0.3)),
+      sat_max(ROSHelpers::GetParamDebugLog<float>(ph, "saturation_max", 1.0)),
+      val_min(ROSHelpers::GetParamDebugLog<float>(ph, "value_min", 0.4)),
+      val_max(ROSHelpers::GetParamDebugLog<float>(ph, "value_max", 1.0))
+{}
+
+SegmenterHSV::SegmenterHSV(ros::NodeHandle& ph, Eigen::Vector3f const last_lower_bounding_box,
+        Eigen::Vector3f const last_upper_bounding_box)
+    : last_lower_bounding_box_{last_lower_bounding_box},
+      last_upper_bounding_box_{last_upper_bounding_box},
+      params_{ph}
+{}
+
+PointCloudHSV SegmenterHSV::get_segmented_cloud() const
+{
+    return *segmented_points_;
+}
+
+void SegmenterHSV::segment(const PointCloudRGB::Ptr & input_points)
+{
+    auto points_cropped = boost::make_shared<PointCloudRGB>();
+    auto points_hsv = boost::make_shared<PointCloudHSV>();
+    auto filtered_points_h = boost::make_shared<PointCloudHSV>();
+    auto filtered_points_hs = boost::make_shared<PointCloudHSV>();
+    auto filtered_points_hsv = boost::make_shared<PointCloudHSV>();
+
+    const Eigen::Vector4f box_min = (last_lower_bounding_box_ - bounding_box_extend).homogeneous();
+    const Eigen::Vector4f box_max = (last_upper_bounding_box_ + bounding_box_extend).homogeneous();
+    ROS_DEBUG_STREAM_NAMED(LOGNAME_SEGMENTER + ".points", "box min: " << box_min.head(3)
+        << " box max " << box_max.head(3));
+
+    // BBOX filter
+    pcl::CropBox<PointRGB> box_filter;
+    box_filter.setMin(box_min);
+    box_filter.setMax(box_max);
+    box_filter.setInputCloud(input_points);
+    box_filter.filter(*points_cropped);
+
+    // convert to HSV
+    pcl::PointCloudXYZRGBtoXYZHSV(*points_cropped, *points_hsv);
+
+    // HSV Filter
+    auto const hue_negative = params_.hue_min > params_.hue_max;
+    auto const sat_negative = params_.sat_min > params_.sat_max;
+    auto const val_negative = params_.val_min > params_.val_max;
+
+    pcl::PassThrough<PointHSV> hue_filter;
+    hue_filter.setInputCloud(points_hsv);
+    hue_filter.setFilterFieldName("h");
+    hue_filter.setFilterLimits(std::min(params_.hue_min, params_.hue_max),
+        std::max(params_.hue_min, params_.hue_max));
+    hue_filter.setFilterLimitsNegative(hue_negative);
+    hue_filter.filter(*filtered_points_h);
+    ROS_DEBUG_STREAM_THROTTLE_NAMED(1, LOGNAME_SEGMENTER + ".points",
+        "hue filtered " << filtered_points_h->size());
+
+    pcl::PassThrough<PointHSV> sat_filter;
+    sat_filter.setInputCloud(filtered_points_h);
+    sat_filter.setFilterFieldName("s");
+    sat_filter.setFilterLimits(std::min(params_.sat_min, params_.sat_max),
+        std::max(params_.sat_min, params_.sat_max));
+    sat_filter.setFilterLimitsNegative(sat_negative);
+    sat_filter.filter(*filtered_points_hs);
+    ROS_DEBUG_STREAM_THROTTLE_NAMED(1, LOGNAME_SEGMENTER + ".points",
+        "sat filtered " << filtered_points_hs->size());
+
+    pcl::PassThrough<PointHSV> val_filter;
+    val_filter.setInputCloud(filtered_points_hs);
+    val_filter.setFilterFieldName("v");
+    val_filter.setFilterLimits(std::min(params_.val_min, params_.val_max),
+        std::max(params_.val_min, params_.val_max));
+    val_filter.setFilterLimitsNegative(val_negative);
+    val_filter.filter(*filtered_points_hsv);
+    ROS_DEBUG_STREAM_THROTTLE_NAMED(1, LOGNAME_SEGMENTER + ".points",
+        "val filtered " << filtered_points_hsv->size());
+
+    // Store results of segmentation in member variable
+    segmented_points_ = std::make_unique<PointCloudHSV>(*filtered_points_hsv);
+}


### PR DESCRIPTION
Adds a class for segmentation so that swapping of segmentation routines should be much easier.

Also does a minor reorganization of the point cloud CDCPD::operator() just to make it a bit easier to read.