### PR TITLE
Add Multi-Template Tracking Map

### DIFF
--- a/cdcpd/CMakeLists.txt
+++ b/cdcpd/CMakeLists.txt
@@ -67,6 +67,7 @@ add_library(cdcpd SHARED
         src/obs_util.cpp
         src/past_template_matcher.cpp
         src/segmenter.cpp
+        src/tracking_map.cpp
         )
 target_include_directories(cdcpd PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/cdcpd/include/cdcpd/cdcpd.h
+++ b/cdcpd/include/cdcpd/cdcpd.h
@@ -113,7 +113,7 @@ class CDCPD {
   // and distance
   Output operator()(const cv::Mat &rgb, const cv::Mat &depth, const cv::Mat &mask,
       const cv::Matx33d &intrinsics, const PointCloud::Ptr template_cloud,
-      ObstacleConstraints points_normals, Eigen::RowVectorXd max_segment_length,
+      ObstacleConstraints points_normals, Eigen::RowVectorXd const max_segment_length,
       const smmap::AllGrippersSinglePoseDelta &q_dot = {},
       const smmap::AllGrippersSinglePose &q_config = {}, const std::vector<bool> &is_grasped = {},
       int pred_choice = 0);
@@ -121,13 +121,13 @@ class CDCPD {
   // If you want to used a known correspondence between grippers and node indices (gripper_idx)
   Output operator()(const cv::Mat &rgb, const cv::Mat &depth, const cv::Mat &mask,
       const cv::Matx33d &intrinsics, const PointCloud::Ptr template_cloud,
-      ObstacleConstraints points_normals, double max_segment_length,
+      ObstacleConstraints points_normals, Eigen::RowVectorXd const max_segment_length,
       const smmap::AllGrippersSinglePoseDelta &q_dot = {},
       const smmap::AllGrippersSinglePose &q_config = {}, const Eigen::MatrixXi &gripper_idx = {},
       int pred_choice = 0);
 
   Output operator()(const PointCloudRGB::Ptr &points, const PointCloud::Ptr template_cloud,
-      ObstacleConstraints points_normals, double max_segment_length,
+      ObstacleConstraints points_normals, Eigen::RowVectorXd const max_segment_length,
       const smmap::AllGrippersSinglePoseDelta &q_dot = {},
       const smmap::AllGrippersSinglePose &q_config = {}, const Eigen::MatrixXi &gripper_idx = {},
       int pred_choice = 0);
@@ -135,7 +135,7 @@ class CDCPD {
   // The common implementation that the above overloads call
   Output operator()(const cv::Mat &rgb, const cv::Mat &depth, const cv::Mat &mask,
       const cv::Matx33d &intrinsics, const PointCloud::Ptr template_cloud,
-      ObstacleConstraints points_normals, double max_segment_length,
+      ObstacleConstraints points_normals, Eigen::RowVectorXd const max_segment_length,
       const smmap::AllGrippersSinglePoseDelta &q_dot = {},  // TODO: this should be one data structure
       const smmap::AllGrippersSinglePose &q_config = {}, int pred_choice = 0);
 

--- a/cdcpd/include/cdcpd/cdcpd.h
+++ b/cdcpd/include/cdcpd/cdcpd.h
@@ -98,49 +98,56 @@ class CDCPD {
     OutputStatus status;
   };
 
-  CDCPD(PointCloud::ConstPtr template_cloud, const Eigen::Matrix2Xi &_template_edges, float objective_value_threshold,
-        bool use_recovery = false, double alpha = 0.5, double beta = 1.0, double lambda = 1.0, double k = 100.0,
-        float zeta = 10.0, float obstacle_cost_weight = 1.0, float fixed_points_weight = 10.0);
+  CDCPD(PointCloud::ConstPtr template_cloud, const Eigen::Matrix2Xi &_template_edges,
+      float objective_value_threshold, bool use_recovery = false, double alpha = 0.5,
+      double beta = 1.0, double lambda = 1.0, double k = 100.0, float zeta = 10.0,
+      float obstacle_cost_weight = 1.0, float fixed_points_weight = 10.0);
 
   CDCPD(ros::NodeHandle nh, ros::NodeHandle ph, PointCloud::ConstPtr template_cloud,
-        const Eigen::Matrix2Xi &_template_edges, float objective_value_threshold, bool use_recovery = false,
-        double alpha = 0.5, double beta = 1.0, double lambda = 1.0, double k = 100.0, float zeta = 10.0,
-        float obstacle_cost_weight = 1.0, float fixed_points_weight = 10.0);
+      const Eigen::Matrix2Xi &_template_edges, float objective_value_threshold,
+      bool use_recovery = false, double alpha = 0.5, double beta = 1.0, double lambda = 1.0,
+      double k = 100.0, float zeta = 10.0, float obstacle_cost_weight = 1.0,
+      float fixed_points_weight = 10.0);
 
-  // If you have want gripper constraints to be added & removed automatically based on is_grasped & distance
-  Output operator()(const cv::Mat &rgb, const cv::Mat &depth, const cv::Mat &mask, const cv::Matx33d &intrinsics,
-                    const PointCloud::Ptr template_cloud, ObstacleConstraints points_normals, double max_segment_length,
-                    const smmap::AllGrippersSinglePoseDelta &q_dot = {},
-                    const smmap::AllGrippersSinglePose &q_config = {}, const std::vector<bool> &is_grasped = {},
-                    int pred_choice = 0);
+  // If you have want gripper constraints to be added and removed automatically based on is_grasped
+  // and distance
+  Output operator()(const cv::Mat &rgb, const cv::Mat &depth, const cv::Mat &mask,
+      const cv::Matx33d &intrinsics, const PointCloud::Ptr template_cloud,
+      ObstacleConstraints points_normals, Eigen::RowVectorXd max_segment_length,
+      const smmap::AllGrippersSinglePoseDelta &q_dot = {},
+      const smmap::AllGrippersSinglePose &q_config = {}, const std::vector<bool> &is_grasped = {},
+      int pred_choice = 0);
 
   // If you want to used a known correspondence between grippers and node indices (gripper_idx)
-  Output operator()(const cv::Mat &rgb, const cv::Mat &depth, const cv::Mat &mask, const cv::Matx33d &intrinsics,
-                    const PointCloud::Ptr template_cloud, ObstacleConstraints points_normals, double max_segment_length,
-                    const smmap::AllGrippersSinglePoseDelta &q_dot = {},
-                    const smmap::AllGrippersSinglePose &q_config = {}, const Eigen::MatrixXi &gripper_idx = {},
-                    int pred_choice = 0);
+  Output operator()(const cv::Mat &rgb, const cv::Mat &depth, const cv::Mat &mask,
+      const cv::Matx33d &intrinsics, const PointCloud::Ptr template_cloud,
+      ObstacleConstraints points_normals, double max_segment_length,
+      const smmap::AllGrippersSinglePoseDelta &q_dot = {},
+      const smmap::AllGrippersSinglePose &q_config = {}, const Eigen::MatrixXi &gripper_idx = {},
+      int pred_choice = 0);
 
   Output operator()(const PointCloudRGB::Ptr &points, const PointCloud::Ptr template_cloud,
-                    ObstacleConstraints points_normals, double max_segment_length,
-                    const smmap::AllGrippersSinglePoseDelta &q_dot = {},
-                    const smmap::AllGrippersSinglePose &q_config = {}, const Eigen::MatrixXi &gripper_idx = {},
-                    int pred_choice = 0);
+      ObstacleConstraints points_normals, double max_segment_length,
+      const smmap::AllGrippersSinglePoseDelta &q_dot = {},
+      const smmap::AllGrippersSinglePose &q_config = {}, const Eigen::MatrixXi &gripper_idx = {},
+      int pred_choice = 0);
 
   // The common implementation that the above overloads call
-  Output operator()(const cv::Mat &rgb, const cv::Mat &depth, const cv::Mat &mask, const cv::Matx33d &intrinsics,
-                    const PointCloud::Ptr template_cloud, ObstacleConstraints points_normals, double max_segment_length,
-                    const smmap::AllGrippersSinglePoseDelta &q_dot = {},  // TODO: this should be one data structure
-                    const smmap::AllGrippersSinglePose &q_config = {}, int pred_choice = 0);
+  Output operator()(const cv::Mat &rgb, const cv::Mat &depth, const cv::Mat &mask,
+      const cv::Matx33d &intrinsics, const PointCloud::Ptr template_cloud,
+      ObstacleConstraints points_normals, double max_segment_length,
+      const smmap::AllGrippersSinglePoseDelta &q_dot = {},  // TODO: this should be one data structure
+      const smmap::AllGrippersSinglePose &q_config = {}, int pred_choice = 0);
 
-  Eigen::VectorXf visibility_prior(const Eigen::Matrix3Xf &vertices, const cv::Mat &depth, const cv::Mat &mask,
-                                   const Eigen::Matrix3f &intrinsics, float kvis);
+  Eigen::VectorXf visibility_prior(const Eigen::Matrix3Xf &vertices, const cv::Mat &depth,
+      const cv::Mat &mask, const Eigen::Matrix3f &intrinsics, float kvis);
 
-  Eigen::Matrix3Xf cpd(const Eigen::Matrix3Xf &X, const Eigen::Matrix3Xf &Y, const Eigen::Matrix3Xf &Y_pred,
-                       const Eigen::VectorXf &Y_emit_prior);
+  Eigen::Matrix3Xf cpd(const Eigen::Matrix3Xf &X, const Eigen::Matrix3Xf &Y,
+      const Eigen::Matrix3Xf &Y_pred, const Eigen::VectorXf &Y_emit_prior);
 
-  Eigen::Matrix3Xd predict(const Eigen::Matrix3Xd &P, const smmap::AllGrippersSinglePoseDelta &q_dot,
-                           const smmap::AllGrippersSinglePose &q_config, int pred_choice);
+  Eigen::Matrix3Xd predict(const Eigen::Matrix3Xd &P,
+      const smmap::AllGrippersSinglePoseDelta &q_dot,
+      const smmap::AllGrippersSinglePose &q_config, int pred_choice);
 
   ros::NodeHandle nh;
   ros::NodeHandle ph;

--- a/cdcpd/include/cdcpd/cdcpd_node.h
+++ b/cdcpd/include/cdcpd/cdcpd_node.h
@@ -140,7 +140,7 @@ public:
     unsigned int gripper_count;
     Eigen::MatrixXi gripper_indices;
 
-    DeformableObjectConfigurationMap deformable_object_tracking_map;
+    TrackingMap deformable_objects;
 
     tf2_ros::Buffer tf_buffer_;
     tf2_ros::TransformListener tf_listener_;

--- a/cdcpd/include/cdcpd/cdcpd_node.h
+++ b/cdcpd/include/cdcpd/cdcpd_node.h
@@ -139,7 +139,8 @@ public:
     unsigned int gripper_count;
     Eigen::MatrixXi gripper_indices;
 
-    std::unique_ptr<DeformableObjectConfiguration> deformable_object_configuration_;
+    // std::unique_ptr<DeformableObjectConfiguration> deformable_object_configuration_;
+    DeformableObjectConfigurationMap deformable_object_tracking_map_;
 
     tf2_ros::Buffer tf_buffer_;
     tf2_ros::TransformListener tf_listener_;

--- a/cdcpd/include/cdcpd/cdcpd_node.h
+++ b/cdcpd/include/cdcpd/cdcpd_node.h
@@ -139,8 +139,7 @@ public:
     unsigned int gripper_count;
     Eigen::MatrixXi gripper_indices;
 
-    // std::unique_ptr<DeformableObjectConfiguration> deformable_object_configuration_;
-    DeformableObjectConfigurationMap deformable_object_tracking_map_;
+    DeformableObjectConfigurationMap deformable_object_tracking_map;
 
     tf2_ros::Buffer tf_buffer_;
     tf2_ros::TransformListener tf_listener_;

--- a/cdcpd/include/cdcpd/cdcpd_node.h
+++ b/cdcpd/include/cdcpd/cdcpd_node.h
@@ -29,6 +29,7 @@
 #include "cdcpd_ros/camera_sub.h"
 #include "cdcpd/deformable_object_configuration.h"
 #include "cdcpd/segmenter.h"
+#include "cdcpd/tracking_map.h"
 
 typedef pcl::PointCloud<pcl::PointXYZ> PointCloud;
 namespace gm = geometry_msgs;

--- a/cdcpd/include/cdcpd/deformable_object_configuration.h
+++ b/cdcpd/include/cdcpd/deformable_object_configuration.h
@@ -98,10 +98,10 @@ public:
     // Returns the matrix describing the maximum length each edge can have.
     Eigen::RowVectorXd form_max_segment_length_matrix() const;
 
-protected:
     // The map that holds the deformable objects we're tracking.
-    std::map<int, std::shared_ptr<DeformableObjectConfiguration> > tracking_map_;
+    std::map<int, std::shared_ptr<DeformableObjectConfiguration> > tracking_map;
 
+protected:
     // The next ID we'll assign to an incoming deformable object configuration to track.
     int deformable_object_id_next_;
 

--- a/cdcpd/include/cdcpd/deformable_object_configuration.h
+++ b/cdcpd/include/cdcpd/deformable_object_configuration.h
@@ -100,10 +100,14 @@ public:
 
 protected:
     // The map that holds the deformable objects we're tracking.
-    std::map<int, std::shared_ptr<DeformableObjectConfiguration> > tracking_map;
+    std::map<int, std::shared_ptr<DeformableObjectConfiguration> > tracking_map_;
 
     // The next ID we'll assign to an incoming deformable object configuration to track.
-    int deformable_object_id_next;
+    int deformable_object_id_next_;
+
+    // Holds the IDs of the tracked objects in a way that preserves order as the map does not.
+    // This is necessary for formation of the vertex, edge, and max segment length matrices.
+    std::vector<int> ordered_def_obj_ids_;
 
     // Return the appropriate DeformableObjectTracking given if we should take the initial or
     // tracked states.

--- a/cdcpd/include/cdcpd/deformable_object_configuration.h
+++ b/cdcpd/include/cdcpd/deformable_object_configuration.h
@@ -71,7 +71,7 @@ public:
 class DeformableObjectConfigurationMap
 {
 public:
-    DeformableObjectConfigurationMap(){}
+    DeformableObjectConfigurationMap();
 
     // Returns the total number of tracked points.
     int get_total_num_points() const;

--- a/cdcpd/include/cdcpd/deformable_object_configuration.h
+++ b/cdcpd/include/cdcpd/deformable_object_configuration.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <tuple>
-#include <map>
 
 #include <Eigen/Dense>
 #include <pcl_ros/point_cloud.h>
@@ -17,14 +16,7 @@ enum DeformableObjectType
     cloth
 };
 
-DeformableObjectType get_deformable_object_type(std::string const& def_obj_type_str)
-{
-    std::map<std::string, DeformableObjectType> obj_type_map{
-        {"rope", DeformableObjectType::rope},
-        {"cloth", DeformableObjectType::cloth}
-    };
-    return obj_type_map[def_obj_type_str];
-}
+DeformableObjectType get_deformable_object_type(std::string const& def_obj_type_str);
 
 struct DeformableObjectTracking
 {
@@ -66,54 +58,6 @@ public:
     float max_segment_length_;
     DeformableObjectTracking tracked_;
     DeformableObjectTracking initial_;
-};
-
-class DeformableObjectConfigurationMap
-{
-public:
-    DeformableObjectConfigurationMap();
-
-    // Returns the total number of tracked points.
-    int get_total_num_points() const;
-
-    // Returns the total number of tracked edges.
-    int get_total_num_edges() const;
-
-    // Returns a map that indicates which vertices belong to which template.
-    // The tuple indicates the start and end vertex indexes that belong to that template.
-    std::map<int, std::tuple<int, int> > get_vertex_assignments() const;
-
-    // Adds the given deformable object configuration to our tracking map.
-    void add_def_obj_configuration(std::shared_ptr<DeformableObjectConfiguration> const def_obj_config);
-
-    // Updates the vertices for all deformable objects given new points predicted from a CDCPD run.
-    void update_def_obj_vertices(pcl::shared_ptr<PointCloud> const vertices_new);
-
-    // Forms the vertices matrix for all tracked templates expected by CDCPD
-    PointCloud::Ptr form_vertices_cloud(bool const use_initial_state=false) const;
-
-    // Forms the edges matrix for all tracked templates expected by CDCPD
-    Eigen::Matrix2Xi form_edges_matrix(bool const use_initial_state=false) const;
-
-    // Returns the matrix describing the maximum length each edge can have.
-    Eigen::RowVectorXd form_max_segment_length_matrix() const;
-
-    // The map that holds the deformable objects we're tracking.
-    std::map<int, std::shared_ptr<DeformableObjectConfiguration> > tracking_map;
-
-protected:
-    // The next ID we'll assign to an incoming deformable object configuration to track.
-    int deformable_object_id_next_;
-
-    // Holds the IDs of the tracked objects in a way that preserves order as the map does not.
-    // This is necessary for formation of the vertex, edge, and max segment length matrices.
-    std::vector<int> ordered_def_obj_ids_;
-
-    // Return the appropriate DeformableObjectTracking given if we should take the initial or
-    // tracked states.
-    std::shared_ptr<DeformableObjectTracking> get_appropriate_tracking(
-        std::shared_ptr<DeformableObjectConfiguration> const def_obj_config,
-        bool take_initial_state) const;
 };
 
 class RopeConfiguration : public DeformableObjectConfiguration

--- a/cdcpd/include/cdcpd/deformable_object_configuration.h
+++ b/cdcpd/include/cdcpd/deformable_object_configuration.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <tuple>
+#include <map>
 
 #include <Eigen/Dense>
 #include <pcl_ros/point_cloud.h>
@@ -65,6 +66,50 @@ public:
     float max_segment_length_;
     DeformableObjectTracking tracked_;
     DeformableObjectTracking initial_;
+};
+
+class DeformableObjectConfigurationMap
+{
+public:
+    DeformableObjectConfigurationMap(){}
+
+    // Returns the total number of tracked points.
+    int get_total_num_points() const;
+
+    // Returns the total number of tracked edges.
+    int get_total_num_edges() const;
+
+    // Returns a map that indicates which vertices belong to which template.
+    // The tuple indicates the start and end vertex indexes that belong to that template.
+    std::map<int, std::tuple<int, int> > get_vertex_assignments() const;
+
+    // Adds the given deformable object configuration to our tracking map.
+    void add_def_obj_configuration(std::shared_ptr<DeformableObjectConfiguration> const def_obj_config);
+
+    // Updates the vertices for all deformable objects given new points predicted from a CDCPD run.
+    void update_def_obj_vertices(pcl::shared_ptr<PointCloud> const vertices_new);
+
+    // Forms the vertices matrix for all tracked templates expected by CDCPD
+    PointCloud::Ptr form_vertices_cloud(bool const use_initial_state=false) const;
+
+    // Forms the edges matrix for all tracked templates expected by CDCPD
+    Eigen::Matrix2Xi form_edges_matrix(bool const use_initial_state=false) const;
+
+    // Returns the matrix describing the maximum length each edge can have.
+    // Eigen::Matrix2Xf form_max_segment_length_matrix() const;
+
+protected:
+    // The map that holds the deformable objects we're tracking.
+    std::map<int, std::shared_ptr<DeformableObjectConfiguration> > tracking_map;
+
+    // The next ID we'll assign to an incoming deformable object configuration to track.
+    int deformable_object_id_next;
+
+    // Return the appropriate DeformableObjectTracking given if we should take the initial or
+    // tracked states.
+    std::shared_ptr<DeformableObjectTracking> get_appropriate_tracking(
+        std::shared_ptr<DeformableObjectConfiguration> const def_obj_config,
+        bool take_initial_state) const;
 };
 
 class RopeConfiguration : public DeformableObjectConfiguration

--- a/cdcpd/include/cdcpd/deformable_object_configuration.h
+++ b/cdcpd/include/cdcpd/deformable_object_configuration.h
@@ -96,7 +96,7 @@ public:
     Eigen::Matrix2Xi form_edges_matrix(bool const use_initial_state=false) const;
 
     // Returns the matrix describing the maximum length each edge can have.
-    // Eigen::Matrix2Xf form_max_segment_length_matrix() const;
+    Eigen::RowVectorXd form_max_segment_length_matrix() const;
 
 protected:
     // The map that holds the deformable objects we're tracking.

--- a/cdcpd/include/cdcpd/optimizer.h
+++ b/cdcpd/include/cdcpd/optimizer.h
@@ -53,40 +53,39 @@ using ObstacleConstraints = std::vector<ObstacleConstraint>;
 
 class Optimizer {
  public:
-  Optimizer(const Eigen::Matrix3Xf initial_template, const Eigen::Matrix3Xf last_template, float stretch_lambda,
-            float obstacle_cost_weight, float fixed_points_weight);
+  Optimizer(const Eigen::Matrix3Xf initial_template, const Eigen::Matrix3Xf last_template,
+      float stretch_lambda, float obstacle_cost_weight, float fixed_points_weight);
 
-  [[nodiscard]] std::pair<Eigen::Matrix3Xf, double> operator()(const Eigen::Matrix3Xf &Y, const Eigen::Matrix2Xi &E,
-                                                               const std::vector<FixedPoint> &fixed_points,
-                                                               ObstacleConstraints const &points_normals,
-                                                               double max_segment_length);
+  [[nodiscard]] std::pair<Eigen::Matrix3Xf, double> operator()(const Eigen::Matrix3Xf &Y,
+      const Eigen::Matrix2Xi &E, const std::vector<FixedPoint> &fixed_points,
+      ObstacleConstraints const &points_normals, double max_segment_length);
 
-  std::tuple<Points, Normals> test_box(const Eigen::Matrix3Xf &last_template, shape_msgs::SolidPrimitive const &box,
-                                       geometry_msgs::Pose const &pose);
+  std::tuple<Points, Normals> test_box(const Eigen::Matrix3Xf &last_template,
+      shape_msgs::SolidPrimitive const &box, geometry_msgs::Pose const &pose);
 
  private:
   [[nodiscard]] bool gripper_constraints_satisfiable(const std::vector<FixedPoint> &fixed_points) const;
 
-  [[nodiscard]] std::tuple<Points, Normals> nearest_points_and_normal_box(const Eigen::Matrix3Xf &last_template,
-                                                                          shape_msgs::SolidPrimitive const &box,
-                                                                          geometry_msgs::Pose const &pose);
+  [[nodiscard]] std::tuple<Points, Normals> nearest_points_and_normal_box(
+      const Eigen::Matrix3Xf &last_template, shape_msgs::SolidPrimitive const &box,
+      geometry_msgs::Pose const &pose);
 
-  [[nodiscard]] std::tuple<Points, Normals> nearest_points_and_normal_sphere(const Eigen::Matrix3Xf &last_template,
-                                                                             shape_msgs::SolidPrimitive const &sphere,
-                                                                             geometry_msgs::Pose const &pose);
+  [[nodiscard]] std::tuple<Points, Normals> nearest_points_and_normal_sphere(
+      const Eigen::Matrix3Xf &last_template, shape_msgs::SolidPrimitive const &sphere,
+      geometry_msgs::Pose const &pose);
 
-  [[nodiscard]] std::tuple<Points, Normals> nearest_points_and_normal_plane(const Eigen::Matrix3Xf &last_template,
-                                                                            shape_msgs::Plane const &plane);
+  [[nodiscard]] std::tuple<Points, Normals> nearest_points_and_normal_plane(
+      const Eigen::Matrix3Xf &last_template, shape_msgs::Plane const &plane);
 
   [[nodiscard]] std::tuple<Points, Normals> nearest_points_and_normal_cylinder(
       const Eigen::Matrix3Xf &last_template, shape_msgs::SolidPrimitive const &cylinder,
       geometry_msgs::Pose const &pose);
 
-  [[nodiscard]] std::tuple<Points, Normals> nearest_points_and_normal_mesh(const Eigen::Matrix3Xf &last_template,
-                                                                           shape_msgs::Mesh const &shapes_mesh);
+  [[nodiscard]] std::tuple<Points, Normals> nearest_points_and_normal_mesh(
+      const Eigen::Matrix3Xf &last_template, shape_msgs::Mesh const &shapes_mesh);
 
-  [[nodiscard]] std::tuple<Points, Normals> nearest_points_and_normal(const Eigen::Matrix3Xf &last_template,
-                                                                      Objects const &objects);
+  [[nodiscard]] std::tuple<Points, Normals> nearest_points_and_normal(
+      const Eigen::Matrix3Xf &last_template, Objects const &objects);
 
   Eigen::Matrix3Xf initial_template_;
   Eigen::Matrix3Xf last_template_;

--- a/cdcpd/include/cdcpd/optimizer.h
+++ b/cdcpd/include/cdcpd/optimizer.h
@@ -58,7 +58,7 @@ class Optimizer {
 
   [[nodiscard]] std::pair<Eigen::Matrix3Xf, double> operator()(const Eigen::Matrix3Xf &Y,
       const Eigen::Matrix2Xi &E, const std::vector<FixedPoint> &fixed_points,
-      ObstacleConstraints const &points_normals, double max_segment_length);
+      ObstacleConstraints const &points_normals, Eigen::RowVectorXd const max_segment_length);
 
   std::tuple<Points, Normals> test_box(const Eigen::Matrix3Xf &last_template,
       shape_msgs::SolidPrimitive const &box, geometry_msgs::Pose const &pose);

--- a/cdcpd/include/cdcpd/tracking_map.h
+++ b/cdcpd/include/cdcpd/tracking_map.h
@@ -8,10 +8,10 @@
 
 #include "cdcpd/deformable_object_configuration.h"
 
-class DeformableObjectConfigurationMap
+class TrackingMap
 {
 public:
-    DeformableObjectConfigurationMap();
+    TrackingMap();
 
     // Returns the total number of tracked points.
     int get_total_num_points() const;

--- a/cdcpd/include/cdcpd/tracking_map.h
+++ b/cdcpd/include/cdcpd/tracking_map.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <map>
+
+#include <Eigen/Dense>
+#include <pcl_ros/point_cloud.h>
+#include <pcl/point_types.h>
+
+#include "cdcpd/deformable_object_configuration.h"
+
+class DeformableObjectConfigurationMap
+{
+public:
+    DeformableObjectConfigurationMap();
+
+    // Returns the total number of tracked points.
+    int get_total_num_points() const;
+
+    // Returns the total number of tracked edges.
+    int get_total_num_edges() const;
+
+    // Returns a map that indicates which vertices belong to which template.
+    // The tuple indicates the start and end vertex indexes that belong to that template.
+    std::map<int, std::tuple<int, int> > get_vertex_assignments() const;
+
+    // Adds the given deformable object configuration to our tracking map.
+    void add_def_obj_configuration(std::shared_ptr<DeformableObjectConfiguration> const def_obj_config);
+
+    // Updates the vertices for all deformable objects given new points predicted from a CDCPD run.
+    void update_def_obj_vertices(pcl::shared_ptr<PointCloud> const vertices_new);
+
+    // Forms the vertices matrix for all tracked templates expected by CDCPD
+    PointCloud::Ptr form_vertices_cloud(bool const use_initial_state=false) const;
+
+    // Forms the edges matrix for all tracked templates expected by CDCPD
+    Eigen::Matrix2Xi form_edges_matrix(bool const use_initial_state=false) const;
+
+    // Returns the matrix describing the maximum length each edge can have.
+    Eigen::RowVectorXd form_max_segment_length_matrix() const;
+
+    // The map that holds the deformable objects we're tracking.
+    std::map<int, std::shared_ptr<DeformableObjectConfiguration> > tracking_map;
+
+protected:
+    // The next ID we'll assign to an incoming deformable object configuration to track.
+    int deformable_object_id_next_;
+
+    // Holds the IDs of the tracked objects in a way that preserves order as the map does not.
+    // This is necessary for formation of the vertex, edge, and max segment length matrices.
+    std::vector<int> ordered_def_obj_ids_;
+
+    // Return the appropriate DeformableObjectTracking given if we should take the initial or
+    // tracked states.
+    std::shared_ptr<DeformableObjectTracking> get_appropriate_tracking(
+        std::shared_ptr<DeformableObjectConfiguration> const def_obj_config,
+        bool take_initial_state) const;
+};

--- a/cdcpd/launch/azure_2_rope.launch
+++ b/cdcpd/launch/azure_2_rope.launch
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<launch>
+
+  <!-- Launch the Azure Kinect driver. -->
+  <include file="$(find azure_kinect_ros_driver)/launch/driver.launch" >
+    <arg name="overwrite_robot_description" value="False" />
+    <arg name="sensor_sn" value="000269420412"/>
+    <arg name="fps" value="30" />
+    <arg name="color_resolution" value="720P" />
+    <arg name="depth_mode" value="NFOV_UNBINNED" />
+  </include>
+
+  <!-- Launch RVIZ with the corresponding Azure Kinect configuration. -->
+  <node name="$(anon rviz)" pkg="rviz" type="rviz" respawn="false" args="-d $(find cdcpd)/rviz/azure_2.rviz" output="screen" />
+
+  <!-- Launch the CDCPD Node -->
+  <env name="ROSCONSOLE_CONFIG_FILE" value="$(find cdcpd)/custom_rosconsole.conf"/>
+
+    <node pkg="cdcpd" type="cdcpd_node" name="cdcpd_node" respawn="false" output="screen">
+        <!-- This file uses the point cloud, but you can also use the RGB and Depth input by
+        commenting the "points" param and uncommenting the "rgb_topic" and "depth_topic" params. -->
+        <param name="points" value="/points2"/>
+        <!-- <param name="rgb_topic" value="/rgb_to_depth/image_raw"/> -->
+        <!-- <param name="depth_topic" value="/depth/image_raw"/> -->
+        <param name="info_topic" value="/depth/camera_info"/>
+        <param name="camera_frame" value="camera_body"/>
+
+        <!-- CDCPD deformable object parameters -->
+        <param name="deformable_object_type" value="rope"/>
+        <param name="num_points" value="15"/>
+        <param name="max_rope_length" value="0.46"/>
+        <param name="lambda" value="1.1"/>
+
+        <!-- CDCPD Node parameters -->
+        <param name="moveit_enabled" value="true"/>
+        <!-- gripper info should be a space seperated list of [TF_NAME IDX TF_NAME IDX ...] -->
+        <param name="grippers_info" value="$(find cdcpd)/gripper_info.yaml"/>
+    </node>
+
+</launch>

--- a/cdcpd/rviz/azure_2.rviz
+++ b/cdcpd/rviz/azure_2.rviz
@@ -11,9 +11,9 @@ Panels:
         - /vision1/kinect1/Occlusion Compensation1
         - /cdcpd1
         - /cdcpd1/BoundingBox1
-        - /cdcpd1/output1/Namespaces1
         - /cdcpd1/masked1
         - /cdcpd1/contacts1/Namespaces1
+        - /cdcpd1/MarkerArray1
         - /PlanningScene1
       Splitter Ratio: 0.40697672963142395
     Tree Height: 837
@@ -35,7 +35,7 @@ Panels:
     Experimental: false
     Name: Time
     SyncMode: 0
-    SyncSource: ""
+    SyncSource: masked
   - Class: merrrt_visualization/AnimationController
     Name: AnimationController
     auto_play: true
@@ -141,14 +141,6 @@ Visualization Manager:
           line width: 0.004999999888241291
           only edge: true
           show coords: false
-        - Class: rviz/Marker
-          Enabled: true
-          Marker Topic: /cdcpd/order
-          Name: output
-          Namespaces:
-            {}
-          Queue Size: 100
-          Value: true
         - Alpha: 1
           Autocompute Intensity Bounds: true
           Autocompute Value Bounds:
@@ -259,6 +251,14 @@ Visualization Manager:
             {}
           Queue Size: 100
           Value: false
+        - Class: rviz/MarkerArray
+          Enabled: true
+          Marker Topic: /cdcpd/order
+          Name: MarkerArray
+          Namespaces:
+            line_order: true
+          Queue Size: 100
+          Value: true
       Enabled: true
       Name: cdcpd
     - Class: moveit_rviz_plugin/PlanningScene
@@ -282,11 +282,6 @@ Visualization Manager:
           Expand Link Details: false
           Expand Tree: false
           Link Tree Style: Links in Alphabetic Order
-          mock_camera_link:
-            Alpha: 1
-            Show Axes: false
-            Show Trail: false
-            Value: true
         Robot Alpha: 1
         Show Robot Collision: false
         Show Robot Visual: true
@@ -335,9 +330,9 @@ Visualization Manager:
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: -1.5697963237762451
+      Pitch: -0.9397965669631958
       Target Frame: anim_camera
-      Yaw: 4.693721294403076
+      Yaw: 4.798727035522461
     Saved: ~
 Window Geometry:
   AnimationController:

--- a/cdcpd/rviz/kinect_tripodB.rviz
+++ b/cdcpd/rviz/kinect_tripodB.rviz
@@ -135,10 +135,10 @@ Visualization Manager:
           line width: 0.004999999888241291
           only edge: true
           show coords: false
-        - Class: rviz/Marker
+        - Class: rviz/MarkerArray
           Enabled: true
           Marker Topic: /cdcpd/order
-          Name: output
+          Name: MarkerArray
           Namespaces:
             line_order: true
           Queue Size: 100

--- a/cdcpd/rviz/realsense.rviz
+++ b/cdcpd/rviz/realsense.rviz
@@ -129,10 +129,10 @@ Visualization Manager:
           line width: 0.004999999888241291
           only edge: true
           show coords: false
-        - Class: rviz/Marker
+        - Class: rviz/MarkerArray
           Enabled: true
           Marker Topic: /cdcpd/order
-          Name: output
+          Name: MarkerArray
           Namespaces:
             line_order: true
           Queue Size: 100

--- a/cdcpd/src/cdcpd.cpp
+++ b/cdcpd/src/cdcpd.cpp
@@ -43,7 +43,8 @@ using Eigen::VectorXd;
 using Eigen::VectorXf;
 using Eigen::VectorXi;
 
-class CompHSV : public pcl::ComparisonBase<PointHSV> {
+class CompHSV : public pcl::ComparisonBase<PointHSV>
+{
   using ComparisonBase<PointHSV>::capable_;
   using ComparisonBase<PointHSV>::op_;
 
@@ -56,7 +57,6 @@ class CompHSV : public pcl::ComparisonBase<PointHSV> {
   CompHSV(const std::string &component_name, pcl::ComparisonOps::CompareOp op, double compare_val)
       : component_offset_(),
         compare_val_(compare_val)
-
   {
     // Verify the component name
     if (component_name == "h") {
@@ -107,7 +107,8 @@ class CompHSV : public pcl::ComparisonBase<PointHSV> {
   CompHSV() : component_offset_(), compare_val_() {}  // not allowed
 };
 
-static PointCloud::Ptr mat_to_cloud(const Eigen::Matrix3Xf &mat) {
+static PointCloud::Ptr mat_to_cloud(const Eigen::Matrix3Xf &mat)
+{
   PointCloud::Ptr cloud(new PointCloud);
   cloud->points.reserve(mat.cols());
   for (ssize_t i = 0; i < mat.cols(); ++i) {
@@ -116,7 +117,8 @@ static PointCloud::Ptr mat_to_cloud(const Eigen::Matrix3Xf &mat) {
   return cloud;
 }
 
-static double initial_sigma2(const MatrixXf &X, const MatrixXf &Y) {
+static double initial_sigma2(const MatrixXf &X, const MatrixXf &Y)
+{
   // X: (3, N) matrix, X^t in Algorithm 1
   // Y: (3, M) matrix, Y^(t-1) in Algorithm 1
   // Implement Line 2 of Algorithm 1
@@ -130,7 +132,8 @@ static double initial_sigma2(const MatrixXf &X, const MatrixXf &Y) {
   return total_error / (X.cols() * Y.cols() * X.rows());
 }
 
-static MatrixXf gaussian_kernel(const MatrixXf &Y, double beta) {
+static MatrixXf gaussian_kernel(const MatrixXf &Y, double beta)
+{
   // Y: (3, M) matrix, corresponding to Y^(t-1) in Eq. 13.5 (Y^t in VI.A)
   // beta: beta in Eq. 13.5 (between 13 and 14)
   MatrixXf diff(Y.cols(), Y.cols());
@@ -145,7 +148,9 @@ static MatrixXf gaussian_kernel(const MatrixXf &Y, double beta) {
   return kernel;
 }
 
-MatrixXf barycenter_kneighbors_graph(const pcl::KdTreeFLANN<pcl::PointXYZ> &kdtree, int lle_neighbors, double reg) {
+MatrixXf barycenter_kneighbors_graph(const pcl::KdTreeFLANN<pcl::PointXYZ> &kdtree,
+    int lle_neighbors, double reg)
+{
   // calculate L in Eq. (15) and Eq. (16)
   // ENHANCE: use tapkee lib to accelarate
   // kdtree: kdtree from Y^0
@@ -190,7 +195,9 @@ MatrixXf barycenter_kneighbors_graph(const pcl::KdTreeFLANN<pcl::PointXYZ> &kdtr
   return graph;
 }
 
-MatrixXf locally_linear_embedding(PointCloud::ConstPtr template_cloud, int lle_neighbors, double reg) {
+MatrixXf locally_linear_embedding(PointCloud::ConstPtr template_cloud, int lle_neighbors,
+    double reg)
+{
   // calculate H in Eq. (18)
   // template_cloud: Y^0 in Eq. (15) and (16)
   // lle_neighbors: parameter for lle calculation
@@ -223,7 +230,8 @@ CDCPD_Parameters::CDCPD_Parameters(ros::NodeHandle& ph)
  * Implement Eq. (7) in the paper
  */
 VectorXf CDCPD::visibility_prior(const Matrix3Xf &vertices, const Mat &depth, const Mat &mask,
-                                 const Matrix3f &intrinsics, const float kvis) {
+                                 const Matrix3f &intrinsics, const float kvis)
+{
   // vertices: (3, M) matrix Y^t (Y in IV.A) in the paper
   // depth: CV_16U depth image
   // mask: CV_8U mask for segmentation
@@ -288,8 +296,10 @@ VectorXf CDCPD::visibility_prior(const Matrix3Xf &vertices, const Mat &depth, co
 // https://github.com/ros-perception/image_pipeline/blob/melodic/depth_image_proc/src/nodelets/point_cloud_xyzrgb.cpp
 // we expect that cx, cy, fx, fy are in the appropriate places in P
 static std::tuple<PointCloudRGB::Ptr, PointCloud::Ptr> point_clouds_from_images(
-    const cv::Mat &depth_image, const cv::Mat &rgb_image, const cv::Mat &mask, const Eigen::Matrix3f &intrinsics,
-    const Eigen::Vector3f &lower_bounding_box, const Eigen::Vector3f &upper_bounding_box) {
+    const cv::Mat &depth_image, const cv::Mat &rgb_image, const cv::Mat &mask,
+    const Eigen::Matrix3f &intrinsics, const Eigen::Vector3f &lower_bounding_box,
+    const Eigen::Vector3f &upper_bounding_box)
+{
   // depth_image: CV_16U depth image
   // rgb_image: CV_8U3C rgb image
   // mask: CV_8U mask for segmentation
@@ -353,7 +363,8 @@ static std::tuple<PointCloudRGB::Ptr, PointCloud::Ptr> point_clouds_from_images(
 }
 
 Matrix3Xf CDCPD::cpd(const Matrix3Xf &X, const Matrix3Xf &Y, const Matrix3Xf &Y_pred,
-                     const Eigen::VectorXf &Y_emit_prior) {
+                     const Eigen::VectorXf &Y_emit_prior)
+{
   // downsampled_cloud: PointXYZ pointer to downsampled point clouds
   // Y: (3, M) matrix Y^t (Y in IV.A) in the paper
   // depth: CV_16U depth image
@@ -453,7 +464,8 @@ Matrix3Xf CDCPD::cpd(const Matrix3Xf &X, const Matrix3Xf &Y, const Matrix3Xf &Y_
 }
 
 Matrix3Xd CDCPD::predict(const Matrix3Xd &P, const smmap::AllGrippersSinglePoseDelta &q_dot,
-                         const smmap::AllGrippersSinglePose &q_config, const int pred_choice) {
+                         const smmap::AllGrippersSinglePose &q_config, const int pred_choice)
+{
   if (pred_choice == 0) {
     return P;
   } else {
@@ -470,16 +482,19 @@ Matrix3Xd CDCPD::predict(const Matrix3Xd &P, const smmap::AllGrippersSinglePoseD
 
 // This is for the case where the gripper indices are unknown (in real experiment)
 CDCPD::CDCPD(PointCloud::ConstPtr template_cloud,  // this needs a different data-type for python
-             const Matrix2Xi &template_edges, const float objective_value_threshold, const bool use_recovery,
-             const double alpha, const double beta, const double lambda, const double k, const float zeta,
-             const float obstacle_cost_weight, const float fixed_points_weight)
-    : CDCPD(ros::NodeHandle(), ros::NodeHandle("~"), template_cloud, template_edges, objective_value_threshold,
-            use_recovery, alpha, beta, lambda, k, zeta, obstacle_cost_weight, fixed_points_weight) {}
+    const Matrix2Xi &template_edges, const float objective_value_threshold, const bool use_recovery,
+    const double alpha, const double beta, const double lambda, const double k, const float zeta,
+    const float obstacle_cost_weight, const float fixed_points_weight)
+    : CDCPD(ros::NodeHandle(), ros::NodeHandle("~"), template_cloud, template_edges,
+        objective_value_threshold, use_recovery, alpha, beta, lambda, k, zeta, obstacle_cost_weight,
+        fixed_points_weight)
+{}
 
 CDCPD::CDCPD(ros::NodeHandle nh, ros::NodeHandle ph, PointCloud::ConstPtr template_cloud,
-             const Matrix2Xi &_template_edges, const float objective_value_threshold, const bool use_recovery,
-             const double alpha, const double beta, const double lambda, const double k, const float zeta,
-             const float obstacle_cost_weight, const float fixed_points_weight)
+    const Matrix2Xi &_template_edges, const float objective_value_threshold,
+    const bool use_recovery, const double alpha, const double beta, const double lambda,
+    const double k, const float zeta, const float obstacle_cost_weight,
+    const float fixed_points_weight)
     : nh(nh),
       ph(ph),
       original_template(template_cloud->getMatrixXfMap().topRows(3)),
@@ -502,7 +517,8 @@ CDCPD::CDCPD(ros::NodeHandle nh, ros::NodeHandle ph, PointCloud::ConstPtr templa
       fixed_points_weight(fixed_points_weight),
       use_recovery(use_recovery),
       last_grasp_status({false, false}),
-      objective_value_threshold_(objective_value_threshold) {
+      objective_value_threshold_(objective_value_threshold)
+{
   last_lower_bounding_box = last_lower_bounding_box - bounding_box_extend;
   last_upper_bounding_box = last_upper_bounding_box + bounding_box_extend;
 
@@ -512,11 +528,12 @@ CDCPD::CDCPD(ros::NodeHandle nh, ros::NodeHandle ph, PointCloud::ConstPtr templa
   L_lle = barycenter_kneighbors_graph(kdtree, lle_neighbors, 0.001);
 }
 
-CDCPD::Output CDCPD::operator()(const Mat &rgb, const Mat &depth, const Mat &mask, const cv::Matx33d &intrinsics,
-                                const PointCloud::Ptr template_cloud, ObstacleConstraints obstacle_constraints,
-                                const double max_segment_length, const smmap::AllGrippersSinglePoseDelta &q_dot,
-                                const smmap::AllGrippersSinglePose &q_config, const std::vector<bool> &is_grasped,
-                                const int pred_choice) {
+CDCPD::Output CDCPD::operator()(const Mat &rgb, const Mat &depth, const Mat &mask,
+    const cv::Matx33d &intrinsics, const PointCloud::Ptr template_cloud,
+    ObstacleConstraints obstacle_constraints, const double max_segment_length,
+    const smmap::AllGrippersSinglePoseDelta &q_dot, const smmap::AllGrippersSinglePose &q_config,
+    const std::vector<bool> &is_grasped, const int pred_choice)
+{
   std::vector<int> idx_map;
   for (auto const &[j, is_grasped_j] : enumerate(is_grasped)) {
     if (j < q_config.size() and j < q_dot.size()) {
@@ -576,11 +593,12 @@ CDCPD::Output CDCPD::operator()(const Mat &rgb, const Mat &depth, const Mat &mas
 }
 
 // NOTE: this is the one I'm current using for rgb + depth
-CDCPD::Output CDCPD::operator()(const Mat &rgb, const Mat &depth, const Mat &mask, const cv::Matx33d &intrinsics,
-                                const PointCloud::Ptr template_cloud, ObstacleConstraints obstacle_constraints,
-                                const double max_segment_length, const smmap::AllGrippersSinglePoseDelta &q_dot,
-                                const smmap::AllGrippersSinglePose &q_config, const Eigen::MatrixXi &gripper_idx,
-                                const int pred_choice) {
+CDCPD::Output CDCPD::operator()(const Mat &rgb, const Mat &depth, const Mat &mask,
+    const cv::Matx33d &intrinsics, const PointCloud::Ptr template_cloud,
+    ObstacleConstraints obstacle_constraints, const double max_segment_length,
+    const smmap::AllGrippersSinglePoseDelta &q_dot, const smmap::AllGrippersSinglePose &q_config,
+    const Eigen::MatrixXi &gripper_idx, const int pred_choice)
+{
   this->gripper_idx = gripper_idx;
   auto const cdcpd_out = operator()(rgb, depth, mask, intrinsics, template_cloud, obstacle_constraints,
                                     max_segment_length, q_dot, q_config, pred_choice);
@@ -588,11 +606,12 @@ CDCPD::Output CDCPD::operator()(const Mat &rgb, const Mat &depth, const Mat &mas
 }
 
 // NOTE: for point cloud inputs
-CDCPD::Output CDCPD::operator()(const PointCloudRGB::Ptr &points, const PointCloud::Ptr template_cloud,
-                                ObstacleConstraints obstacle_constraints, const double max_segment_length,
-                                const smmap::AllGrippersSinglePoseDelta &q_dot,
-                                const smmap::AllGrippersSinglePose &q_config, const Eigen::MatrixXi &gripper_idx,
-                                const int pred_choice) {
+CDCPD::Output CDCPD::operator()(const PointCloudRGB::Ptr &points,
+    const PointCloud::Ptr template_cloud, ObstacleConstraints obstacle_constraints,
+    const double max_segment_length, const smmap::AllGrippersSinglePoseDelta &q_dot,
+    const smmap::AllGrippersSinglePose &q_config, const Eigen::MatrixXi &gripper_idx,
+    const int pred_choice)
+{
   // FIXME: this has a lot of duplicate code
   this->gripper_idx = gripper_idx;
 
@@ -688,10 +707,12 @@ CDCPD::Output CDCPD::operator()(const PointCloudRGB::Ptr &points, const PointClo
   return CDCPD::Output{points, cloud, cloud_downsampled, cdcpd_cpd, cdcpd_pred, cdcpd_out, status};
 }
 
-CDCPD::Output CDCPD::operator()(const Mat &rgb, const Mat &depth, const Mat &mask, const cv::Matx33d &intrinsics,
-                                const PointCloud::Ptr template_cloud, ObstacleConstraints obstacle_constraints,
-                                const double max_segment_length, const smmap::AllGrippersSinglePoseDelta &q_dot,
-                                const smmap::AllGrippersSinglePose &q_config, const int pred_choice) {
+CDCPD::Output CDCPD::operator()(const Mat &rgb, const Mat &depth, const Mat &mask,
+    const cv::Matx33d &intrinsics, const PointCloud::Ptr template_cloud,
+    ObstacleConstraints obstacle_constraints, const double max_segment_length,
+    const smmap::AllGrippersSinglePoseDelta &q_dot, const smmap::AllGrippersSinglePose &q_config,
+    const int pred_choice)
+{
   // rgb: CV_8U3C rgb image
   // depth: CV_16U depth image
   // mask: CV_8U mask for segmentation

--- a/cdcpd/src/cdcpd.cpp
+++ b/cdcpd/src/cdcpd.cpp
@@ -530,7 +530,7 @@ CDCPD::CDCPD(ros::NodeHandle nh, ros::NodeHandle ph, PointCloud::ConstPtr templa
 
 CDCPD::Output CDCPD::operator()(const Mat &rgb, const Mat &depth, const Mat &mask,
     const cv::Matx33d &intrinsics, const PointCloud::Ptr template_cloud,
-    ObstacleConstraints obstacle_constraints, const double max_segment_length,
+    ObstacleConstraints obstacle_constraints, Eigen::RowVectorXd const max_segment_length,
     const smmap::AllGrippersSinglePoseDelta &q_dot, const smmap::AllGrippersSinglePose &q_config,
     const std::vector<bool> &is_grasped, const int pred_choice)
 {
@@ -595,7 +595,7 @@ CDCPD::Output CDCPD::operator()(const Mat &rgb, const Mat &depth, const Mat &mas
 // NOTE: this is the one I'm current using for rgb + depth
 CDCPD::Output CDCPD::operator()(const Mat &rgb, const Mat &depth, const Mat &mask,
     const cv::Matx33d &intrinsics, const PointCloud::Ptr template_cloud,
-    ObstacleConstraints obstacle_constraints, const double max_segment_length,
+    ObstacleConstraints obstacle_constraints, Eigen::RowVectorXd const max_segment_length,
     const smmap::AllGrippersSinglePoseDelta &q_dot, const smmap::AllGrippersSinglePose &q_config,
     const Eigen::MatrixXi &gripper_idx, const int pred_choice)
 {
@@ -608,7 +608,7 @@ CDCPD::Output CDCPD::operator()(const Mat &rgb, const Mat &depth, const Mat &mas
 // NOTE: for point cloud inputs
 CDCPD::Output CDCPD::operator()(const PointCloudRGB::Ptr &points,
     const PointCloud::Ptr template_cloud, ObstacleConstraints obstacle_constraints,
-    const double max_segment_length, const smmap::AllGrippersSinglePoseDelta &q_dot,
+    Eigen::RowVectorXd const max_segment_length, const smmap::AllGrippersSinglePoseDelta &q_dot,
     const smmap::AllGrippersSinglePose &q_config, const Eigen::MatrixXi &gripper_idx,
     const int pred_choice)
 {
@@ -709,7 +709,7 @@ CDCPD::Output CDCPD::operator()(const PointCloudRGB::Ptr &points,
 
 CDCPD::Output CDCPD::operator()(const Mat &rgb, const Mat &depth, const Mat &mask,
     const cv::Matx33d &intrinsics, const PointCloud::Ptr template_cloud,
-    ObstacleConstraints obstacle_constraints, const double max_segment_length,
+    ObstacleConstraints obstacle_constraints, Eigen::RowVectorXd const max_segment_length,
     const smmap::AllGrippersSinglePoseDelta &q_dot, const smmap::AllGrippersSinglePose &q_config,
     const int pred_choice)
 {
@@ -789,7 +789,8 @@ CDCPD::Output CDCPD::operator()(const Mat &rgb, const Mat &depth, const Mat &mas
   // NOTE: seems like this should be a function, not a class? is there state like the gurobi env?
   // ???: most likely not 1.0
   Optimizer opt(original_template, Y, start_lambda, obstacle_cost_weight, fixed_points_weight);
-  auto const opt_out = opt(TY, template_edges, pred_fixed_points, obstacle_constraints, max_segment_length);
+  auto const opt_out =
+      opt(TY, template_edges, pred_fixed_points, obstacle_constraints, max_segment_length);
   Matrix3Xf Y_opt = opt_out.first;
   double objective_value = opt_out.second;
 

--- a/cdcpd/src/cdcpd_node.cpp
+++ b/cdcpd/src/cdcpd_node.cpp
@@ -195,17 +195,17 @@ void CDCPD_Moveit_Node::initialize_deformable_object_configuration(
     std::shared_ptr<DeformableObjectConfiguration> deformable_object_configuration;
     if (node_params.deformable_object_type == DeformableObjectType::rope)
     {
-        auto configuration = std::unique_ptr<RopeConfiguration>(new RopeConfiguration(
+        auto configuration = std::shared_ptr<RopeConfiguration>(new RopeConfiguration(
             node_params.num_points, node_params.max_rope_length, rope_start_position,
             rope_end_position));
         // Have to call initializeTracking() before casting to base class since it relies on virtual
         // functions.
         configuration->initializeTracking();
-        deformable_object_configuration = std::move(configuration);
+        deformable_object_configuration = configuration;
     }
     else if (node_params.deformable_object_type == DeformableObjectType::cloth)
     {
-        auto configuration = std::unique_ptr<ClothConfiguration>(new ClothConfiguration(
+        auto configuration = std::shared_ptr<ClothConfiguration>(new ClothConfiguration(
             node_params.length_initial_cloth, node_params.width_initial_cloth,
             node_params.grid_size_initial_guess_cloth));
 
@@ -220,7 +220,7 @@ void CDCPD_Moveit_Node::initialize_deformable_object_configuration(
         // Have to call initializeTracking() before casting to base class since it relies on virtual
         // functions.
         configuration->initializeTracking();
-        deformable_object_configuration = std::move(configuration);
+        deformable_object_configuration = configuration;
     }
 
     // Add the initialized configuration to our tracking map.

--- a/cdcpd/src/cdcpd_node.cpp
+++ b/cdcpd/src/cdcpd_node.cpp
@@ -103,7 +103,7 @@ CDCPD_Moveit_Node::CDCPD_Moveit_Node(std::string const& robot_namespace)
       model_loader_(std::make_shared<robot_model_loader::RobotModelLoader>(robot_description_)),
       model_(model_loader_->getModel()),
       visual_tools_("robot_root", "cdcpd_moveit_node", scene_monitor_),
-      deformable_object_tracking_map_(),
+      deformable_object_tracking_map(),
       tf_listener_(tf_buffer_)
 {
     auto const scene_topic = ros::names::append(robot_namespace,
@@ -162,8 +162,8 @@ CDCPD_Moveit_Node::CDCPD_Moveit_Node(std::string const& robot_namespace)
     initialize_deformable_object_configuration(start_position_1, end_position_1);
     // initialize_deformable_object_configuration(start_position_2, end_position_2);
 
-    PointCloud::Ptr vertices = deformable_object_tracking_map_.form_vertices_cloud();
-    Eigen::Matrix2Xi edges = deformable_object_tracking_map_.form_edges_matrix();
+    PointCloud::Ptr vertices = deformable_object_tracking_map.form_vertices_cloud();
+    Eigen::Matrix2Xi edges = deformable_object_tracking_map.form_edges_matrix();
     cdcpd = std::make_unique<CDCPD>(nh, ph, vertices, edges,
         cdcpd_params.objective_value_threshold, cdcpd_params.use_recovery, cdcpd_params.alpha,
         cdcpd_params.beta, cdcpd_params.lambda, cdcpd_params.k_spring, cdcpd_params.zeta,
@@ -232,7 +232,7 @@ void CDCPD_Moveit_Node::initialize_deformable_object_configuration(
     }
 
     // Add the initialized configuration to our tracking map.
-    deformable_object_tracking_map_.add_def_obj_configuration(deformable_object_configuration);
+    deformable_object_tracking_map.add_def_obj_configuration(deformable_object_configuration);
 }
 
 ObstacleConstraints CDCPD_Moveit_Node::find_nearest_points_and_normals(
@@ -471,12 +471,12 @@ void CDCPD_Moveit_Node::callback(cv::Mat const& rgb, cv::Mat const& depth,
     auto obstacle_constraints = get_obstacle_constraints();
 
     auto const hsv_mask = getHsvMask(ph, rgb);
-    PointCloud::Ptr vertices = deformable_object_tracking_map_.form_vertices_cloud();
+    PointCloud::Ptr vertices = deformable_object_tracking_map.form_vertices_cloud();
     Eigen::RowVectorXd max_segment_lengths =
-        deformable_object_tracking_map_.form_max_segment_length_matrix();
+        deformable_object_tracking_map.form_max_segment_length_matrix();
     auto const out = (*cdcpd)(rgb, depth, hsv_mask, intrinsics, vertices, obstacle_constraints,
         max_segment_lengths, q_dot, q_config, gripper_indices);
-    deformable_object_tracking_map_.update_def_obj_vertices(out.gurobi_output);
+    deformable_object_tracking_map.update_def_obj_vertices(out.gurobi_output);
     publish_outputs(t0, out);
     reset_if_bad(out);
 };
@@ -496,12 +496,12 @@ void CDCPD_Moveit_Node::points_callback(const sensor_msgs::PointCloud2ConstPtr& 
     pcl::fromPCLPointCloud2(points_v2, *points);
     ROS_DEBUG_STREAM_NAMED(LOGNAME, "unfiltered points: " << points->size());
 
-    PointCloud::Ptr vertices = deformable_object_tracking_map_.form_vertices_cloud();
+    PointCloud::Ptr vertices = deformable_object_tracking_map.form_vertices_cloud();
     Eigen::RowVectorXd max_segment_lengths =
-        deformable_object_tracking_map_.form_max_segment_length_matrix();
+        deformable_object_tracking_map.form_max_segment_length_matrix();
     auto const out = (*cdcpd)(points, vertices, obstacle_constraints, max_segment_lengths, q_dot,
         q_config, gripper_indices);
-    deformable_object_tracking_map_.update_def_obj_vertices(out.gurobi_output);
+    deformable_object_tracking_map.update_def_obj_vertices(out.gurobi_output);
     publish_outputs(t0, out);
     reset_if_bad(out);
 }
@@ -531,7 +531,7 @@ void CDCPD_Moveit_Node::publish_template() const
     auto time = ros::Time::now();
     // TODO(Dylan): Make this a message array instead of just a single point cloud??
     // Get the point cloud representing all of our templates.
-    PointCloud::Ptr templates_cloud = deformable_object_tracking_map_.form_vertices_cloud();
+    PointCloud::Ptr templates_cloud = deformable_object_tracking_map.form_vertices_cloud();
     templates_cloud->header.frame_id = node_params.camera_frame;
     pcl_conversions::toPCL(time, templates_cloud->header.stamp);
 
@@ -543,7 +543,7 @@ ObstacleConstraints CDCPD_Moveit_Node::get_obstacle_constraints()
     ObstacleConstraints obstacle_constraints;
     if (moveit_ready and node_params.moveit_enabled)
     {
-        PointCloud::Ptr vertices = deformable_object_tracking_map_.form_vertices_cloud();
+        PointCloud::Ptr vertices = deformable_object_tracking_map.form_vertices_cloud();
         obstacle_constraints = get_moveit_obstacle_constriants(vertices);
         ROS_DEBUG_NAMED(LOGNAME + ".moveit", "Got moveit obstacle constraints");
     }
@@ -586,7 +586,7 @@ void CDCPD_Moveit_Node::publish_outputs(ros::Time const& t0, CDCPD::Output const
         {
             vm::MarkerArray rope_orders;
             int i = 1;
-            for (auto const& def_obj_pair : deformable_object_tracking_map_.tracking_map)
+            for (auto const& def_obj_pair : deformable_object_tracking_map.tracking_map)
             {
                 int const& def_obj_id = def_obj_pair.first;
                 auto const& def_obj_config = def_obj_pair.second;
@@ -658,9 +658,9 @@ void CDCPD_Moveit_Node::reset_if_bad(CDCPD::Output const& out)
         // Recreate CDCPD from initial tracking.
         bool const use_initial_state = true;
         PointCloud::Ptr vertices =
-            deformable_object_tracking_map_.form_vertices_cloud(use_initial_state);
+            deformable_object_tracking_map.form_vertices_cloud(use_initial_state);
         Eigen::Matrix2Xi edges =
-            deformable_object_tracking_map_.form_edges_matrix(use_initial_state);
+            deformable_object_tracking_map.form_edges_matrix(use_initial_state);
 
         std::unique_ptr<CDCPD> cdcpd_new(new CDCPD(nh, ph, vertices, edges,
             cdcpd_params.objective_value_threshold, cdcpd_params.use_recovery, cdcpd_params.alpha,

--- a/cdcpd/src/cdcpd_node.cpp
+++ b/cdcpd/src/cdcpd_node.cpp
@@ -103,7 +103,7 @@ CDCPD_Moveit_Node::CDCPD_Moveit_Node(std::string const& robot_namespace)
       model_loader_(std::make_shared<robot_model_loader::RobotModelLoader>(robot_description_)),
       model_(model_loader_->getModel()),
       visual_tools_("robot_root", "cdcpd_moveit_node", scene_monitor_),
-      deformable_object_tracking_map(),
+      deformable_objects(),
       tf_listener_(tf_buffer_)
 {
     auto const scene_topic = ros::names::append(robot_namespace,
@@ -162,8 +162,8 @@ CDCPD_Moveit_Node::CDCPD_Moveit_Node(std::string const& robot_namespace)
     initialize_deformable_object_configuration(start_position_1, end_position_1);
     // initialize_deformable_object_configuration(start_position_2, end_position_2);
 
-    PointCloud::Ptr vertices = deformable_object_tracking_map.form_vertices_cloud();
-    Eigen::Matrix2Xi edges = deformable_object_tracking_map.form_edges_matrix();
+    PointCloud::Ptr vertices = deformable_objects.form_vertices_cloud();
+    Eigen::Matrix2Xi edges = deformable_objects.form_edges_matrix();
     cdcpd = std::make_unique<CDCPD>(nh, ph, vertices, edges,
         cdcpd_params.objective_value_threshold, cdcpd_params.use_recovery, cdcpd_params.alpha,
         cdcpd_params.beta, cdcpd_params.lambda, cdcpd_params.k_spring, cdcpd_params.zeta,
@@ -232,7 +232,7 @@ void CDCPD_Moveit_Node::initialize_deformable_object_configuration(
     }
 
     // Add the initialized configuration to our tracking map.
-    deformable_object_tracking_map.add_def_obj_configuration(deformable_object_configuration);
+    deformable_objects.add_def_obj_configuration(deformable_object_configuration);
 }
 
 ObstacleConstraints CDCPD_Moveit_Node::find_nearest_points_and_normals(
@@ -471,12 +471,12 @@ void CDCPD_Moveit_Node::callback(cv::Mat const& rgb, cv::Mat const& depth,
     auto obstacle_constraints = get_obstacle_constraints();
 
     auto const hsv_mask = getHsvMask(ph, rgb);
-    PointCloud::Ptr vertices = deformable_object_tracking_map.form_vertices_cloud();
+    PointCloud::Ptr vertices = deformable_objects.form_vertices_cloud();
     Eigen::RowVectorXd max_segment_lengths =
-        deformable_object_tracking_map.form_max_segment_length_matrix();
+        deformable_objects.form_max_segment_length_matrix();
     auto const out = (*cdcpd)(rgb, depth, hsv_mask, intrinsics, vertices, obstacle_constraints,
         max_segment_lengths, q_dot, q_config, gripper_indices);
-    deformable_object_tracking_map.update_def_obj_vertices(out.gurobi_output);
+    deformable_objects.update_def_obj_vertices(out.gurobi_output);
     publish_outputs(t0, out);
     reset_if_bad(out);
 };
@@ -496,12 +496,12 @@ void CDCPD_Moveit_Node::points_callback(const sensor_msgs::PointCloud2ConstPtr& 
     pcl::fromPCLPointCloud2(points_v2, *points);
     ROS_DEBUG_STREAM_NAMED(LOGNAME, "unfiltered points: " << points->size());
 
-    PointCloud::Ptr vertices = deformable_object_tracking_map.form_vertices_cloud();
+    PointCloud::Ptr vertices = deformable_objects.form_vertices_cloud();
     Eigen::RowVectorXd max_segment_lengths =
-        deformable_object_tracking_map.form_max_segment_length_matrix();
+        deformable_objects.form_max_segment_length_matrix();
     auto const out = (*cdcpd)(points, vertices, obstacle_constraints, max_segment_lengths, q_dot,
         q_config, gripper_indices);
-    deformable_object_tracking_map.update_def_obj_vertices(out.gurobi_output);
+    deformable_objects.update_def_obj_vertices(out.gurobi_output);
     publish_outputs(t0, out);
     reset_if_bad(out);
 }
@@ -531,7 +531,7 @@ void CDCPD_Moveit_Node::publish_template() const
     auto time = ros::Time::now();
     // TODO(Dylan): Make this a message array instead of just a single point cloud??
     // Get the point cloud representing all of our templates.
-    PointCloud::Ptr templates_cloud = deformable_object_tracking_map.form_vertices_cloud();
+    PointCloud::Ptr templates_cloud = deformable_objects.form_vertices_cloud();
     templates_cloud->header.frame_id = node_params.camera_frame;
     pcl_conversions::toPCL(time, templates_cloud->header.stamp);
 
@@ -543,7 +543,7 @@ ObstacleConstraints CDCPD_Moveit_Node::get_obstacle_constraints()
     ObstacleConstraints obstacle_constraints;
     if (moveit_ready and node_params.moveit_enabled)
     {
-        PointCloud::Ptr vertices = deformable_object_tracking_map.form_vertices_cloud();
+        PointCloud::Ptr vertices = deformable_objects.form_vertices_cloud();
         obstacle_constraints = get_moveit_obstacle_constriants(vertices);
         ROS_DEBUG_NAMED(LOGNAME + ".moveit", "Got moveit obstacle constraints");
     }
@@ -586,7 +586,7 @@ void CDCPD_Moveit_Node::publish_outputs(ros::Time const& t0, CDCPD::Output const
         {
             vm::MarkerArray rope_orders;
             int i = 1;
-            for (auto const& def_obj_pair : deformable_object_tracking_map.tracking_map)
+            for (auto const& def_obj_pair : deformable_objects.tracking_map)
             {
                 int const& def_obj_id = def_obj_pair.first;
                 auto const& def_obj_config = def_obj_pair.second;
@@ -658,9 +658,9 @@ void CDCPD_Moveit_Node::reset_if_bad(CDCPD::Output const& out)
         // Recreate CDCPD from initial tracking.
         bool const use_initial_state = true;
         PointCloud::Ptr vertices =
-            deformable_object_tracking_map.form_vertices_cloud(use_initial_state);
+            deformable_objects.form_vertices_cloud(use_initial_state);
         Eigen::Matrix2Xi edges =
-            deformable_object_tracking_map.form_edges_matrix(use_initial_state);
+            deformable_objects.form_edges_matrix(use_initial_state);
 
         std::unique_ptr<CDCPD> cdcpd_new(new CDCPD(nh, ph, vertices, edges,
             cdcpd_params.objective_value_threshold, cdcpd_params.use_recovery, cdcpd_params.alpha,

--- a/cdcpd/src/deformable_object_configuration.cpp
+++ b/cdcpd/src/deformable_object_configuration.cpp
@@ -151,7 +151,7 @@ void DeformableObjectConfigurationMap::update_def_obj_vertices(
 PointCloud::Ptr DeformableObjectConfigurationMap::form_vertices_cloud(
     bool const use_initial_state) const
 {
-    PointCloud::Ptr vertices_cloud;
+    PointCloud::Ptr vertices_cloud(new PointCloud);
     // I don't think we actually care about the stamp at this point.
     // bool stamp_copied = false;
     for (auto const& def_obj_id : ordered_def_obj_ids_)

--- a/cdcpd/src/deformable_object_configuration.cpp
+++ b/cdcpd/src/deformable_object_configuration.cpp
@@ -149,7 +149,7 @@ void DeformableObjectConfigurationMap::update_def_obj_vertices(
 }
 
 PointCloud::Ptr DeformableObjectConfigurationMap::form_vertices_cloud(
-    bool const use_initial_state=false) const
+    bool const use_initial_state) const
 {
     PointCloud::Ptr vertices_cloud;
     // I don't think we actually care about the stamp at this point.
@@ -170,7 +170,7 @@ PointCloud::Ptr DeformableObjectConfigurationMap::form_vertices_cloud(
 }
 
 Eigen::Matrix2Xi DeformableObjectConfigurationMap::form_edges_matrix(
-    bool const use_initial_state=false) const
+    bool const use_initial_state) const
 {
     int const num_edges_total = get_total_num_edges();
 
@@ -217,7 +217,7 @@ Eigen::RowVectorXd DeformableObjectConfigurationMap::form_max_segment_length_mat
         double const def_obj_max_segment_length = def_obj_config->max_segment_length_;
         for (int i = 0; i < def_obj_config->tracked_.edges_.cols(); ++i)
         {
-            max_segment_lengths[1, edge_idx_aggregate] = def_obj_max_segment_length;
+            max_segment_lengths(0, edge_idx_aggregate) = def_obj_max_segment_length;
             ++edge_idx_aggregate;
         }
     }
@@ -232,11 +232,11 @@ std::shared_ptr<DeformableObjectTracking> DeformableObjectConfigurationMap::get_
     std::shared_ptr<DeformableObjectTracking> tracking;
     if (take_initial_state)
     {
-        tracking = std::make_shared<DeformableObjectTracking>(&def_obj_config->initial_);
+        tracking = std::make_shared<DeformableObjectTracking>(def_obj_config->initial_);
     }
     else
     {
-        tracking = std::make_shared<DeformableObjectTracking>(&def_obj_config->tracked_);
+        tracking = std::make_shared<DeformableObjectTracking>(def_obj_config->tracked_);
     }
     return tracking;
 }

--- a/cdcpd/src/deformable_object_configuration.cpp
+++ b/cdcpd/src/deformable_object_configuration.cpp
@@ -74,10 +74,13 @@ DeformableObjectConfigurationMap::DeformableObjectConfigurationMap()
 int DeformableObjectConfigurationMap::get_total_num_points() const
 {
     int num_points_total = 0;
-    for (auto const& tracked_pair : tracking_map_)
+    for (auto const& def_obj_id : ordered_def_obj_ids_)
     {
-
+        std::shared_ptr<DeformableObjectConfiguration> def_obj_config =
+            tracking_map_.at(def_obj_id);
+        num_points_total += def_obj_config->num_points_;
     }
+    return num_points_total;
 }
 
 int DeformableObjectConfigurationMap::get_total_num_edges() const

--- a/cdcpd/src/deformable_object_configuration.cpp
+++ b/cdcpd/src/deformable_object_configuration.cpp
@@ -6,6 +6,15 @@ int unravel_indices(int row, int col, int num_points_width)
     return row * num_points_width + col;
 }
 
+DeformableObjectType get_deformable_object_type(std::string const& def_obj_type_str)
+{
+    std::map<std::string, DeformableObjectType> obj_type_map{
+        {"rope", DeformableObjectType::rope},
+        {"cloth", DeformableObjectType::cloth}
+    };
+    return obj_type_map[def_obj_type_str];
+}
+
 DeformableObjectTracking::DeformableObjectTracking(DeformableObjectTracking const& other)
 {
     vertices_ = other.vertices_;
@@ -63,184 +72,6 @@ void DeformableObjectConfiguration::initializeTracking()
     DeformableObjectTracking object_tracking = makeTemplate();
     tracked_ = DeformableObjectTracking(object_tracking);
     initial_ = DeformableObjectTracking(object_tracking);
-}
-
-DeformableObjectConfigurationMap::DeformableObjectConfigurationMap()
-    : tracking_map(),
-      deformable_object_id_next_(0),
-      ordered_def_obj_ids_()
-{}
-
-int DeformableObjectConfigurationMap::get_total_num_points() const
-{
-    int num_points_total = 0;
-    for (auto const& def_obj_id : ordered_def_obj_ids_)
-    {
-        std::shared_ptr<DeformableObjectConfiguration> def_obj_config =
-            tracking_map.at(def_obj_id);
-        num_points_total += def_obj_config->num_points_;
-    }
-    return num_points_total;
-}
-
-int DeformableObjectConfigurationMap::get_total_num_edges() const
-{
-    int num_edges_total = 0;
-    for (auto const& tracked_pair : tracking_map)
-    {
-        std::shared_ptr<DeformableObjectConfiguration> const& def_obj_config = tracked_pair.second;
-        int num_edges = def_obj_config->tracked_.edges_.cols();
-        num_edges_total += num_edges;
-    }
-    return num_edges_total;
-}
-
-std::map<int, std::tuple<int, int> > DeformableObjectConfigurationMap::get_vertex_assignments() const
-{
-    // NOTE: This could be kept track of as a member variable and instead updated any time a
-    // deformable object is added/removed.
-    std::map<int, std::tuple<int, int> > vertex_assignments;
-    int idx_begin = 0;
-    for (auto const& configuration : tracking_map)
-    {
-        int idx_end = idx_begin + configuration.second->num_points_;
-        std::tuple<int, int> idx_range{idx_begin, idx_end};
-        idx_begin = idx_end;
-
-        vertex_assignments.emplace(configuration.first, idx_range);
-    }
-    return vertex_assignments;
-}
-
-void DeformableObjectConfigurationMap::add_def_obj_configuration(
-    std::shared_ptr<DeformableObjectConfiguration> const def_obj_config)
-{
-    tracking_map.emplace(deformable_object_id_next_, def_obj_config);
-
-    // Just insert the deformable object ID at the back or our track ID list since we know this ID
-    // is the greatest ID (since we just increment the ID each time).
-    ordered_def_obj_ids_.push_back(deformable_object_id_next_);
-
-    ++deformable_object_id_next_;
-}
-
-void DeformableObjectConfigurationMap::update_def_obj_vertices(
-    pcl::shared_ptr<PointCloud> const vertices_new)
-{
-    auto vertex_assignments = get_vertex_assignments();
-    auto const& cloud_it_begin = vertices_new->begin();
-    for (auto const& assignment_range : vertex_assignments)
-    {
-        // Get the deformable object configuration we're updating.
-        int const& def_obj_id = assignment_range.first;
-        std::shared_ptr<DeformableObjectConfiguration>& def_obj_config = tracking_map[def_obj_id];
-
-        // Grab the range of indices where this configuration's points will be stored in the point
-        // cloud.
-        std::tuple<int, int> const& idx_range = assignment_range.second;
-        int const& idx_start = std::get<0>(idx_range);
-        int const& idx_end = std::get<1>(idx_range);
-
-        // Use the point cloud iterators and std::copy to efficiently update the tracked points.
-        auto const& it_begin = cloud_it_begin + idx_start;
-        auto const& it_end = cloud_it_begin + idx_end;
-        std::copy(it_begin, it_end, def_obj_config->tracked_.points_->begin());
-
-        def_obj_config->tracked_.vertices_ = def_obj_config->tracked_.points_->getMatrixXfMap().topRows(3);
-    }
-}
-
-PointCloud::Ptr DeformableObjectConfigurationMap::form_vertices_cloud(
-    bool const use_initial_state) const
-{
-    PointCloud::Ptr vertices_cloud(new PointCloud);
-    // I don't think we actually care about the stamp at this point.
-    // bool stamp_copied = false;
-    for (auto const& def_obj_id : ordered_def_obj_ids_)
-    {
-        // Grab the deformable object configuration.
-        std::shared_ptr<DeformableObjectConfiguration> const def_obj_config =
-            tracking_map.at(def_obj_id);
-
-        std::shared_ptr<DeformableObjectTracking> tracking =
-            get_appropriate_tracking(def_obj_config, use_initial_state);
-
-        // Concatenate this deformable object's point cloud with the aggregate point cloud.
-        (*vertices_cloud) += (*tracking->points_);
-    }
-    return vertices_cloud;
-}
-
-Eigen::Matrix2Xi DeformableObjectConfigurationMap::form_edges_matrix(
-    bool const use_initial_state) const
-{
-    int const num_edges_total = get_total_num_edges();
-
-    // Initialize an Eigen matrix for keeping track of the edges.
-    Eigen::Matrix2Xi edges_total(2, num_edges_total);
-
-    // Populate that edge matrix based on all of our edges.
-    int edge_idx_aggregate = 0;
-    for (auto const& def_obj_id : ordered_def_obj_ids_)
-    {
-        // Grab the deformable object configuration.
-        std::shared_ptr<DeformableObjectConfiguration> const def_obj_config =
-            tracking_map.at(def_obj_id);
-
-        std::shared_ptr<DeformableObjectTracking> tracking =
-            get_appropriate_tracking(def_obj_config, use_initial_state);
-
-        Eigen::Matrix2Xi const& edges = tracking->edges_;
-        for (int edge_col = 0; edge_col < edges.cols(); ++edge_col)
-        {
-            edges_total.col(edge_idx_aggregate) = edges.col(edge_col);
-            ++edge_idx_aggregate;
-        }
-    }
-    return edges_total;
-}
-
-Eigen::RowVectorXd DeformableObjectConfigurationMap::form_max_segment_length_matrix() const
-{
-    // Construct the structure that will hold the edge lengths.
-    int const num_edges_total = get_total_num_edges();
-    Eigen::RowVectorXd max_segment_lengths(num_edges_total);
-
-    // Populate the edge length structure.
-    // Right now this isn't very interesting but one could envisage dynamically refining tracking
-    // by placing more Gaussians in areas of uncertainty, changing the maximum segment length based
-    // on the new edges created.
-    size_t edge_idx_aggregate = 0;
-    for (auto const& def_obj_id : ordered_def_obj_ids_)
-    {
-        std::shared_ptr<DeformableObjectConfiguration> const def_obj_config =
-            tracking_map.at(def_obj_id);
-
-        double const def_obj_max_segment_length = def_obj_config->max_segment_length_;
-        for (int i = 0; i < def_obj_config->tracked_.edges_.cols(); ++i)
-        {
-            max_segment_lengths(0, edge_idx_aggregate) = def_obj_max_segment_length;
-            ++edge_idx_aggregate;
-        }
-    }
-
-    return max_segment_lengths;
-}
-
-std::shared_ptr<DeformableObjectTracking> DeformableObjectConfigurationMap::get_appropriate_tracking(
-        std::shared_ptr<DeformableObjectConfiguration> const def_obj_config,
-        bool take_initial_state) const
-{
-    std::shared_ptr<DeformableObjectTracking> tracking;
-    if (take_initial_state)
-    {
-        tracking = std::make_shared<DeformableObjectTracking>(def_obj_config->initial_);
-    }
-    else
-    {
-        tracking = std::make_shared<DeformableObjectTracking>(def_obj_config->tracked_);
-    }
-    return tracking;
 }
 
 RopeConfiguration::RopeConfiguration(int const num_points, float const max_rope_length,

--- a/cdcpd/src/optimizer.cpp
+++ b/cdcpd/src/optimizer.cpp
@@ -40,7 +40,9 @@ static Eigen::Vector3f const bounding_box_extend;
 // This is equivalent to [point_a' point_b'] * Q * [point_a' point_b']'
 // where Q is [ I, -I
 //             -I,  I]
-static GRBQuadExpr buildDifferencingQuadraticTerm(GRBVar *point_a, GRBVar *point_b, const size_t num_vars_per_point) {
+static GRBQuadExpr buildDifferencingQuadraticTerm(GRBVar *point_a, GRBVar *point_b,
+    const size_t num_vars_per_point)
+{
   GRBQuadExpr expr;
 
   // Build the main diagonal
@@ -55,7 +57,8 @@ static GRBQuadExpr buildDifferencingQuadraticTerm(GRBVar *point_a, GRBVar *point
   return expr;
 }
 
-static GRBEnv &getGRBEnv() {
+static GRBEnv &getGRBEnv()
+{
   try {
     static GRBEnv env;
     return env;
@@ -65,12 +68,19 @@ static GRBEnv &getGRBEnv() {
   }
 }
 
-static Vector3f cgalVec2EigenVec(Vector cgal_v) { return Vector3f(cgal_v[0], cgal_v[1], cgal_v[2]); }
+static Vector3f cgalVec2EigenVec(Vector cgal_v)
+{
+    return Vector3f(cgal_v[0], cgal_v[1], cgal_v[2]);
+}
 
-static Vector3f Pt3toVec(const Point_3 pt) { return Vector3f(float(pt.x()), float(pt.y()), float(pt.z())); }
+static Vector3f Pt3toVec(const Point_3 pt)
+{
+    return Vector3f(float(pt.x()), float(pt.y()), float(pt.z()));
+}
 
 std::tuple<Points, Normals> Optimizer::nearest_points_and_normal(const Matrix3Xf &last_template,
-                                                                 Objects const &objects) {
+    Objects const &objects)
+{
   for (auto const &object : objects) {
     // Meshes
     if (object.meshes.size() != object.mesh_poses.size()) {
@@ -154,8 +164,8 @@ std::tuple<Points, Normals> Optimizer::nearest_points_and_normal(const Matrix3Xf
 }
 
 std::tuple<Points, Normals> Optimizer::nearest_points_and_normal_box(const Matrix3Xf &last_template,
-                                                                     shape_msgs::SolidPrimitive const &box,
-                                                                     geometry_msgs::Pose const &pose) {
+    shape_msgs::SolidPrimitive const &box, geometry_msgs::Pose const &pose)
+{
   auto const position = ConvertTo<Vector3f>(pose.position);
   auto const orientation = ConvertTo<Eigen::Quaternionf>(pose.orientation).toRotationMatrix();
   auto const box_x = box.dimensions[shape_msgs::SolidPrimitive::BOX_X];
@@ -225,24 +235,26 @@ std::tuple<Points, Normals> Optimizer::nearest_points_and_normal_box(const Matri
   return {nearestPts, normalVecs};
 }
 
-std::tuple<Points, Normals> Optimizer::nearest_points_and_normal_sphere(const Matrix3Xf &last_template,
-                                                                        shape_msgs::SolidPrimitive const &,
-                                                                        geometry_msgs::Pose const &) {
+std::tuple<Points, Normals> Optimizer::nearest_points_and_normal_sphere(
+    const Matrix3Xf &last_template, shape_msgs::SolidPrimitive const &, geometry_msgs::Pose const &)
+{
   Matrix3Xf nearestPts(3, last_template.cols());
   Matrix3Xf normalVecs(3, last_template.cols());
   return {nearestPts, normalVecs};
 }
 
-std::tuple<Points, Normals> Optimizer::nearest_points_and_normal_plane(const Matrix3Xf &last_template,
-                                                                       shape_msgs::Plane const &) {
+std::tuple<Points, Normals> Optimizer::nearest_points_and_normal_plane(
+    const Matrix3Xf &last_template, shape_msgs::Plane const &)
+{
   Matrix3Xf nearestPts(3, last_template.cols());
   Matrix3Xf normalVecs(3, last_template.cols());
   return {nearestPts, normalVecs};
 }
 
-std::tuple<Points, Normals> Optimizer::nearest_points_and_normal_cylinder(const Matrix3Xf &last_template,
-                                                                          shape_msgs::SolidPrimitive const &cylinder,
-                                                                          geometry_msgs::Pose const &pose) {
+std::tuple<Points, Normals> Optimizer::nearest_points_and_normal_cylinder(
+    const Matrix3Xf &last_template, shape_msgs::SolidPrimitive const &cylinder,
+    geometry_msgs::Pose const &pose)
+{
   auto const position = ConvertTo<Vector3f>(pose.position);
   // NOTE: Yixuan, should orientation be roll, pitch, yaw here?
   // Answer: As what I can recall, the orientation is the unit vector along center axis
@@ -299,8 +311,9 @@ std::tuple<Points, Normals> Optimizer::nearest_points_and_normal_cylinder(const 
   return {nearestPts, normalVecs};
 }
 
-std::tuple<Points, Normals> Optimizer::nearest_points_and_normal_mesh(const Matrix3Xf &last_template,
-                                                                      shape_msgs::Mesh const &shapes_mesh) {
+std::tuple<Points, Normals> Optimizer::nearest_points_and_normal_mesh(
+    const Matrix3Xf &last_template, shape_msgs::Mesh const &shapes_mesh)
+{
   auto mesh = shapes_mesh_to_cgal_mesh(shapes_mesh);
   auto const fnormals = mesh.add_property_map<face_descriptor, Vector>("f:normals", CGAL::NULL_VECTOR).first;
   auto const vnormals = mesh.add_property_map<vertex_descriptor, Vector>("v:normals", CGAL::NULL_VECTOR).first;
@@ -345,7 +358,9 @@ std::tuple<Points, Normals> Optimizer::nearest_points_and_normal_mesh(const Matr
   return {nearestPts, normalVecs};
 }
 
-std::tuple<MatrixXf, MatrixXf> nearest_points_line_segments(const Matrix3Xf &last_template, const Matrix2Xi &E) {
+std::tuple<MatrixXf, MatrixXf> nearest_points_line_segments(const Matrix3Xf &last_template,
+    const Matrix2Xi &E)
+{
   // find the nearest points on the line segments
   // refer to the website https://math.stackexchange.com/questions/846054/closest-points-on-two-line-segments
   MatrixXf startPts(
@@ -406,23 +421,24 @@ std::tuple<MatrixXf, MatrixXf> nearest_points_line_segments(const Matrix3Xf &las
 }
 
 std::tuple<Points, Normals> Optimizer::test_box(const Eigen::Matrix3Xf &last_template,
-                                                shape_msgs::SolidPrimitive const &box,
-                                                geometry_msgs::Pose const &pose) {
+    shape_msgs::SolidPrimitive const &box, geometry_msgs::Pose const &pose)
+{
   return nearest_points_and_normal_box(last_template, box, pose);
 }
 
 Optimizer::Optimizer(const Eigen::Matrix3Xf initial_template, const Eigen::Matrix3Xf last_template,
-                     const float stretch_lambda, const float obstacle_cost_weight, const float fixed_points_weight)
+    const float stretch_lambda, const float obstacle_cost_weight, const float fixed_points_weight)
     : initial_template_(initial_template),
       last_template_(last_template),
       stretch_lambda_(stretch_lambda),
       obstacle_cost_weight_(obstacle_cost_weight),
-      fixed_points_weight_(fixed_points_weight) {}
+      fixed_points_weight_(fixed_points_weight)
+{}
 
 std::pair<Matrix3Xf, double> Optimizer::operator()(const Matrix3Xf &Y, const Matrix2Xi &E,
-                                                   const std::vector<FixedPoint> &fixed_points,
-                                                   ObstacleConstraints const &obstacle_constraints,
-                                                   const double max_segment_length) {
+    const std::vector<FixedPoint> &fixed_points, ObstacleConstraints const &obstacle_constraints,
+    const double max_segment_length)
+{
   // Y: Y^t in Eq. (21)
   // E: E in Eq. (21)
   Matrix3Xf Y_opt(Y.rows(), Y.cols());
@@ -569,7 +585,8 @@ std::pair<Matrix3Xf, double> Optimizer::operator()(const Matrix3Xf &Y, const Mat
   return {Y_opt, final_objective_value};
 }
 
-bool Optimizer::gripper_constraints_satisfiable(const std::vector<FixedPoint> &fixed_points) const {
+bool Optimizer::gripper_constraints_satisfiable(const std::vector<FixedPoint> &fixed_points) const
+{
   for (auto const &p1 : fixed_points) {
     for (auto const &p2 : fixed_points) {
       float const current_distance = (p1.position - p2.position).squaredNorm();

--- a/cdcpd/src/tracking_map.cpp
+++ b/cdcpd/src/tracking_map.cpp
@@ -1,12 +1,12 @@
 #include "cdcpd/tracking_map.h"
 
-DeformableObjectConfigurationMap::DeformableObjectConfigurationMap()
+TrackingMap::TrackingMap()
     : tracking_map(),
       deformable_object_id_next_(0),
       ordered_def_obj_ids_()
 {}
 
-int DeformableObjectConfigurationMap::get_total_num_points() const
+int TrackingMap::get_total_num_points() const
 {
     int num_points_total = 0;
     for (auto const& def_obj_id : ordered_def_obj_ids_)
@@ -18,7 +18,7 @@ int DeformableObjectConfigurationMap::get_total_num_points() const
     return num_points_total;
 }
 
-int DeformableObjectConfigurationMap::get_total_num_edges() const
+int TrackingMap::get_total_num_edges() const
 {
     int num_edges_total = 0;
     for (auto const& tracked_pair : tracking_map)
@@ -30,7 +30,7 @@ int DeformableObjectConfigurationMap::get_total_num_edges() const
     return num_edges_total;
 }
 
-std::map<int, std::tuple<int, int> > DeformableObjectConfigurationMap::get_vertex_assignments() const
+std::map<int, std::tuple<int, int> > TrackingMap::get_vertex_assignments() const
 {
     // NOTE: This could be kept track of as a member variable and instead updated any time a
     // deformable object is added/removed.
@@ -47,7 +47,7 @@ std::map<int, std::tuple<int, int> > DeformableObjectConfigurationMap::get_verte
     return vertex_assignments;
 }
 
-void DeformableObjectConfigurationMap::add_def_obj_configuration(
+void TrackingMap::add_def_obj_configuration(
     std::shared_ptr<DeformableObjectConfiguration> const def_obj_config)
 {
     tracking_map.emplace(deformable_object_id_next_, def_obj_config);
@@ -59,8 +59,7 @@ void DeformableObjectConfigurationMap::add_def_obj_configuration(
     ++deformable_object_id_next_;
 }
 
-void DeformableObjectConfigurationMap::update_def_obj_vertices(
-    pcl::shared_ptr<PointCloud> const vertices_new)
+void TrackingMap::update_def_obj_vertices(pcl::shared_ptr<PointCloud> const vertices_new)
 {
     auto vertex_assignments = get_vertex_assignments();
     auto const& cloud_it_begin = vertices_new->begin();
@@ -85,8 +84,7 @@ void DeformableObjectConfigurationMap::update_def_obj_vertices(
     }
 }
 
-PointCloud::Ptr DeformableObjectConfigurationMap::form_vertices_cloud(
-    bool const use_initial_state) const
+PointCloud::Ptr TrackingMap::form_vertices_cloud(bool const use_initial_state) const
 {
     PointCloud::Ptr vertices_cloud(new PointCloud);
     // I don't think we actually care about the stamp at this point.
@@ -106,8 +104,7 @@ PointCloud::Ptr DeformableObjectConfigurationMap::form_vertices_cloud(
     return vertices_cloud;
 }
 
-Eigen::Matrix2Xi DeformableObjectConfigurationMap::form_edges_matrix(
-    bool const use_initial_state) const
+Eigen::Matrix2Xi TrackingMap::form_edges_matrix(bool const use_initial_state) const
 {
     int const num_edges_total = get_total_num_edges();
 
@@ -135,7 +132,7 @@ Eigen::Matrix2Xi DeformableObjectConfigurationMap::form_edges_matrix(
     return edges_total;
 }
 
-Eigen::RowVectorXd DeformableObjectConfigurationMap::form_max_segment_length_matrix() const
+Eigen::RowVectorXd TrackingMap::form_max_segment_length_matrix() const
 {
     // Construct the structure that will hold the edge lengths.
     int const num_edges_total = get_total_num_edges();
@@ -162,7 +159,7 @@ Eigen::RowVectorXd DeformableObjectConfigurationMap::form_max_segment_length_mat
     return max_segment_lengths;
 }
 
-std::shared_ptr<DeformableObjectTracking> DeformableObjectConfigurationMap::get_appropriate_tracking(
+std::shared_ptr<DeformableObjectTracking> TrackingMap::get_appropriate_tracking(
         std::shared_ptr<DeformableObjectConfiguration> const def_obj_config,
         bool take_initial_state) const
 {

--- a/cdcpd/src/tracking_map.cpp
+++ b/cdcpd/src/tracking_map.cpp
@@ -1,0 +1,179 @@
+#include "cdcpd/tracking_map.h"
+
+DeformableObjectConfigurationMap::DeformableObjectConfigurationMap()
+    : tracking_map(),
+      deformable_object_id_next_(0),
+      ordered_def_obj_ids_()
+{}
+
+int DeformableObjectConfigurationMap::get_total_num_points() const
+{
+    int num_points_total = 0;
+    for (auto const& def_obj_id : ordered_def_obj_ids_)
+    {
+        std::shared_ptr<DeformableObjectConfiguration> def_obj_config =
+            tracking_map.at(def_obj_id);
+        num_points_total += def_obj_config->num_points_;
+    }
+    return num_points_total;
+}
+
+int DeformableObjectConfigurationMap::get_total_num_edges() const
+{
+    int num_edges_total = 0;
+    for (auto const& tracked_pair : tracking_map)
+    {
+        std::shared_ptr<DeformableObjectConfiguration> const& def_obj_config = tracked_pair.second;
+        int num_edges = def_obj_config->tracked_.edges_.cols();
+        num_edges_total += num_edges;
+    }
+    return num_edges_total;
+}
+
+std::map<int, std::tuple<int, int> > DeformableObjectConfigurationMap::get_vertex_assignments() const
+{
+    // NOTE: This could be kept track of as a member variable and instead updated any time a
+    // deformable object is added/removed.
+    std::map<int, std::tuple<int, int> > vertex_assignments;
+    int idx_begin = 0;
+    for (auto const& configuration : tracking_map)
+    {
+        int idx_end = idx_begin + configuration.second->num_points_;
+        std::tuple<int, int> idx_range{idx_begin, idx_end};
+        idx_begin = idx_end;
+
+        vertex_assignments.emplace(configuration.first, idx_range);
+    }
+    return vertex_assignments;
+}
+
+void DeformableObjectConfigurationMap::add_def_obj_configuration(
+    std::shared_ptr<DeformableObjectConfiguration> const def_obj_config)
+{
+    tracking_map.emplace(deformable_object_id_next_, def_obj_config);
+
+    // Just insert the deformable object ID at the back or our track ID list since we know this ID
+    // is the greatest ID (since we just increment the ID each time).
+    ordered_def_obj_ids_.push_back(deformable_object_id_next_);
+
+    ++deformable_object_id_next_;
+}
+
+void DeformableObjectConfigurationMap::update_def_obj_vertices(
+    pcl::shared_ptr<PointCloud> const vertices_new)
+{
+    auto vertex_assignments = get_vertex_assignments();
+    auto const& cloud_it_begin = vertices_new->begin();
+    for (auto const& assignment_range : vertex_assignments)
+    {
+        // Get the deformable object configuration we're updating.
+        int const& def_obj_id = assignment_range.first;
+        std::shared_ptr<DeformableObjectConfiguration>& def_obj_config = tracking_map[def_obj_id];
+
+        // Grab the range of indices where this configuration's points will be stored in the point
+        // cloud.
+        std::tuple<int, int> const& idx_range = assignment_range.second;
+        int const& idx_start = std::get<0>(idx_range);
+        int const& idx_end = std::get<1>(idx_range);
+
+        // Use the point cloud iterators and std::copy to efficiently update the tracked points.
+        auto const& it_begin = cloud_it_begin + idx_start;
+        auto const& it_end = cloud_it_begin + idx_end;
+        std::copy(it_begin, it_end, def_obj_config->tracked_.points_->begin());
+
+        def_obj_config->tracked_.vertices_ = def_obj_config->tracked_.points_->getMatrixXfMap().topRows(3);
+    }
+}
+
+PointCloud::Ptr DeformableObjectConfigurationMap::form_vertices_cloud(
+    bool const use_initial_state) const
+{
+    PointCloud::Ptr vertices_cloud(new PointCloud);
+    // I don't think we actually care about the stamp at this point.
+    // bool stamp_copied = false;
+    for (auto const& def_obj_id : ordered_def_obj_ids_)
+    {
+        // Grab the deformable object configuration.
+        std::shared_ptr<DeformableObjectConfiguration> const def_obj_config =
+            tracking_map.at(def_obj_id);
+
+        std::shared_ptr<DeformableObjectTracking> tracking =
+            get_appropriate_tracking(def_obj_config, use_initial_state);
+
+        // Concatenate this deformable object's point cloud with the aggregate point cloud.
+        (*vertices_cloud) += (*tracking->points_);
+    }
+    return vertices_cloud;
+}
+
+Eigen::Matrix2Xi DeformableObjectConfigurationMap::form_edges_matrix(
+    bool const use_initial_state) const
+{
+    int const num_edges_total = get_total_num_edges();
+
+    // Initialize an Eigen matrix for keeping track of the edges.
+    Eigen::Matrix2Xi edges_total(2, num_edges_total);
+
+    // Populate that edge matrix based on all of our edges.
+    int edge_idx_aggregate = 0;
+    for (auto const& def_obj_id : ordered_def_obj_ids_)
+    {
+        // Grab the deformable object configuration.
+        std::shared_ptr<DeformableObjectConfiguration> const def_obj_config =
+            tracking_map.at(def_obj_id);
+
+        std::shared_ptr<DeformableObjectTracking> tracking =
+            get_appropriate_tracking(def_obj_config, use_initial_state);
+
+        Eigen::Matrix2Xi const& edges = tracking->edges_;
+        for (int edge_col = 0; edge_col < edges.cols(); ++edge_col)
+        {
+            edges_total.col(edge_idx_aggregate) = edges.col(edge_col);
+            ++edge_idx_aggregate;
+        }
+    }
+    return edges_total;
+}
+
+Eigen::RowVectorXd DeformableObjectConfigurationMap::form_max_segment_length_matrix() const
+{
+    // Construct the structure that will hold the edge lengths.
+    int const num_edges_total = get_total_num_edges();
+    Eigen::RowVectorXd max_segment_lengths(num_edges_total);
+
+    // Populate the edge length structure.
+    // Right now this isn't very interesting but one could envisage dynamically refining tracking
+    // by placing more Gaussians in areas of uncertainty, changing the maximum segment length based
+    // on the new edges created.
+    size_t edge_idx_aggregate = 0;
+    for (auto const& def_obj_id : ordered_def_obj_ids_)
+    {
+        std::shared_ptr<DeformableObjectConfiguration> const def_obj_config =
+            tracking_map.at(def_obj_id);
+
+        double const def_obj_max_segment_length = def_obj_config->max_segment_length_;
+        for (int i = 0; i < def_obj_config->tracked_.edges_.cols(); ++i)
+        {
+            max_segment_lengths(0, edge_idx_aggregate) = def_obj_max_segment_length;
+            ++edge_idx_aggregate;
+        }
+    }
+
+    return max_segment_lengths;
+}
+
+std::shared_ptr<DeformableObjectTracking> DeformableObjectConfigurationMap::get_appropriate_tracking(
+        std::shared_ptr<DeformableObjectConfiguration> const def_obj_config,
+        bool take_initial_state) const
+{
+    std::shared_ptr<DeformableObjectTracking> tracking;
+    if (take_initial_state)
+    {
+        tracking = std::make_shared<DeformableObjectTracking>(def_obj_config->initial_);
+    }
+    else
+    {
+        tracking = std::make_shared<DeformableObjectTracking>(def_obj_config->tracked_);
+    }
+    return tracking;
+}

--- a/cdcpd/tests/integration/static_rope.cpp
+++ b/cdcpd/tests/integration/static_rope.cpp
@@ -65,8 +65,13 @@ PointCloud::Ptr resimulateCdcpd(CDCPD& cdcpd_sim,
 {
     // Do some setup of parameters and gripper configuration.
     PointCloud::Ptr tracked_points = initial_tracked_points;
+
     ObstacleConstraints obstacle_constraints;  // No need to specify anything with this demo.
+
     float const max_segment_length = max_rope_length / static_cast<float>(num_points);
+    Eigen::RowVectorXd max_segment_lengths =
+        Eigen::RowVectorXd::Ones(num_points) * max_segment_length;
+
     unsigned int gripper_count = 0U;
     smmap::AllGrippersSinglePose q_config;
     const smmap::AllGrippersSinglePoseDelta q_dot{gripper_count, kinematics::Vector6d::Zero()};
@@ -79,7 +84,7 @@ PointCloud::Ptr resimulateCdcpd(CDCPD& cdcpd_sim,
         // Run a single "iteration" of CDCPD mimicing the points_callback lambda function found in
         // cdcpd_node.cpp
         CDCPD::Output out = cdcpd_sim(cloud, tracked_points, obstacle_constraints,
-            max_segment_length, q_dot, q_config, gripper_indices);
+            max_segment_lengths, q_dot, q_config, gripper_indices);
         tracked_points = out.gurobi_output;
 
         // Do a health check of CDCPD


### PR DESCRIPTION
# High-Level Description

Adds the ability for CDCPD to run on multiple deformable object configurations by storing a map of configurations by unique ID (ID unique to each deformable object configuration).

This does NOT implement multiple template tracking in the sense of:
- Learning separate LLE weights for separate templates given different initial template states.
- Separating multiple deformable object configurations in the CPD step, meaning that the masked points that belong to another template still impact the CPD score of another, separate deformable object configuration.
- Using masked point association history to disambiguate multi-template (non-instance) segmentation, meaning that if CDCPD receives a mask indicating there are two deformable objects in the segmentation that are interacting, there's no way to tell them apart in the tracking's use of the segmented mask.

## Key Changes

- Adds a std::map to keep track of deformable object configurations (how tracked templates are stored) by unique IDs. 
- Changes max segment length to be per edge so that edges can have different maximum lengths.
    - Something of this flavor is necessary to specify max edge lengths based on each template's (potentially different) edge lengths compared to any other template's edge lengths.
    - Though, it's up for debate as to whether this is the best way to handle this.
- Updates the RVIZ edge visualization to only connect tracked points that belong to the same template.
    - Accomplishes this by publishing a MarkerArray message instead of a single Marker message.
    - TODO: Connect points based on the edge list. This would make the visualization respect the actual edges and thus correctly visualize cloth.

## Miscellaneous Changes

- Formats CDCPD and Optimizer function signatures as they could have been considered hard to read.